### PR TITLE
修复媒体上传类型为thumb时的返回值解析问题

### DIFF
--- a/material/media.go
+++ b/material/media.go
@@ -33,6 +33,7 @@ type Media struct {
 
 	Type      MediaType `json:"type"`
 	MediaID   string    `json:"media_id"`
+	ThumbMediaID string `json:"thumb_media_id"`
 	CreatedAt int64     `json:"created_at"`
 }
 


### PR DESCRIPTION
实际返回如下：{"type":"thumb","thumb_media_id":"mediaId","created_at":1486032778}