### PR TITLE
微信开放平台网页应用获取oauth回调地址

### DIFF
--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -11,11 +11,12 @@ import (
 )
 
 const (
-	redirectOauthURL      = "https://open.weixin.qq.com/connect/oauth2/authorize?appid=%s&redirect_uri=%s&response_type=code&scope=%s&state=%s#wechat_redirect"
-	accessTokenURL        = "https://api.weixin.qq.com/sns/oauth2/access_token?appid=%s&secret=%s&code=%s&grant_type=authorization_code"
-	refreshAccessTokenURL = "https://api.weixin.qq.com/sns/oauth2/refresh_token?appid=%s&grant_type=refresh_token&refresh_token=%s"
-	userInfoURL           = "https://api.weixin.qq.com/sns/userinfo?access_token=%s&openid=%s&lang=zh_CN"
-	checkAccessTokenURL   = "https://api.weixin.qq.com/sns/auth?access_token=%s&openid=%s"
+	redirectOauthURL       = "https://open.weixin.qq.com/connect/oauth2/authorize?appid=%s&redirect_uri=%s&response_type=code&scope=%s&state=%s#wechat_redirect"
+	webAppRedirectOauthURL = "https://open.weixin.qq.com/connect/qrconnect?appid=%s&redirect_uri=%s&response_type=code&scope=%s&state=%s#wechat_redirect"
+	accessTokenURL         = "https://api.weixin.qq.com/sns/oauth2/access_token?appid=%s&secret=%s&code=%s&grant_type=authorization_code"
+	refreshAccessTokenURL  = "https://api.weixin.qq.com/sns/oauth2/refresh_token?appid=%s&grant_type=refresh_token&refresh_token=%s"
+	userInfoURL            = "https://api.weixin.qq.com/sns/userinfo?access_token=%s&openid=%s&lang=zh_CN"
+	checkAccessTokenURL    = "https://api.weixin.qq.com/sns/auth?access_token=%s&openid=%s"
 )
 
 //Oauth 保存用户授权信息
@@ -35,6 +36,12 @@ func (oauth *Oauth) GetRedirectURL(redirectURI, scope, state string) (string, er
 	//url encode
 	urlStr := url.QueryEscape(redirectURI)
 	return fmt.Sprintf(redirectOauthURL, oauth.AppID, urlStr, scope, state), nil
+}
+
+//GetWebAppRedirectURL 获取网页应用跳转的url地址
+func (oauth *Oauth) GetWebAppRedirectURL(redirectURI, scope, state string) (string, error) {
+	urlStr := url.QueryEscape(redirectURI)
+	return fmt.Sprintf(webAppRedirectOauthURL, oauth.AppID, urlStr, scope, state), nil
 }
 
 //Redirect 跳转到网页授权


### PR DESCRIPTION
微信开放平台的回调地址生成规则跟微信公众平台的不一样,但是回调的code和获取access_token的方法是一样的，所以整合进来，文档：https://open.weixin.qq.com/cgi-bin/showdocument?action=dir_list&t=resource/res_list&verify=1&id=open1419316505&token=6f9d9aab70716b33f1ac8bc269efad2e93ce4249&lang=zh_CN
这个是生成网页二维码，然微信扫码登陆返回code获取access_token