### PR TITLE
remove   1.7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ go:
   - 1.10.x
   - 1.9.x
   - 1.8.x
-  - 1.7.x
 
 services:
   - memcached


### PR DESCRIPTION
移除go 1.7.x版本支持，主要是解决example中beego依赖 ci失败 #83 

不过不是必须