### PR TITLE
add http proxy,resolved #73

### DIFF
--- a/util/http.go
+++ b/util/http.go
@@ -12,15 +12,15 @@ import (
 	"net/url"
 	"os"
 )
-// proxyUrl 代理URL
-var proxyUrl string
+// proxyURL 代理URL
+var proxyURL string
 
 // proxy 是否开启代理
 var proxy bool
 
 // SetProxy 设置代理URL
 func SetProxy(url string){
-	proxyUrl = url
+	proxyURL = url
 	proxy = len(url)>0
 }
 // OpenProxy 打开代理
@@ -88,7 +88,7 @@ func PostFile(fieldname, filename, uri string) ([]byte, error) {
 func GetHTTPClient()(httpClient *http.Client){
 	if proxy {
 		proxy := func(_ *http.Request) (*url.URL, error) {
-			return url.Parse(proxyUrl)
+			return url.Parse(proxyURL)
 		}
 		httpTransport := &http.Transport{
 			Proxy: proxy,

--- a/util/http_test.go
+++ b/util/http_test.go
@@ -1,0 +1,27 @@
+package util
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestHTTPGet(t *testing.T) {
+	//abc sig
+	SetProxy("socks5://127.0.0.1:1080")
+	url := "https://api.ip.sb/ip"
+	resp,_ := HTTPGet(url)
+	//如果resp打印是代理的IP，则代理成功
+	fmt.Println(string(resp))
+
+	CloseProxy()
+	resp,_ = HTTPGet(url)
+	//如果resp打印是本机IP，则关闭代理成功
+	fmt.Println(string(resp))
+
+	OpenProxy()
+
+	resp,_ = HTTPGet(url)
+	//如果resp打印是代理的IP，则打开代理成功
+	fmt.Println(string(resp))
+
+}


### PR DESCRIPTION
增加http的简单代理，不支持账号密码代理，设置代理方式为：在任意地方调用util.SetProxy("这里制定代理的URL")即可