### PR TITLE
支付 新增 BridgeConfig 方法，可获得 prepay ID，及js支付时所需要的参数

### DIFF
--- a/pay/pay.go
+++ b/pay/pay.go
@@ -163,8 +163,8 @@ func (pcf *Pay) PrePayOrder(p *Params) (payOrder PreOrder, err error) {
 		param["sign_type"] = p.SignType
 	}
 	// 通知地址
-	if p.NotifyUrl != "" {
-		param["notify_url"] = p.NotifyUrl
+	if p.NotifyURL != "" {
+		param["notify_url"] = p.NotifyURL
 	}
 
 	bizKey := "&key=" + pcf.PayKey

--- a/pay/pay.go
+++ b/pay/pay.go
@@ -38,7 +38,7 @@ type Params struct {
 	Detail     string
 	Attach     string
 	GoodsTag   string
-	NotifyUrl  string
+	NotifyURL  string
 }
 
 // Config 是传出用于 js sdk 用的参数
@@ -67,7 +67,7 @@ type PreOrder struct {
 	ErrCodeDes string `xml:"err_code_des,omitempty"`
 }
 
-//payRequest 接口请求参数
+// payRequest 接口请求参数
 type payRequest struct {
 	AppID          string `xml:"appid"`
 	MchID          string `xml:"mch_id"`
@@ -77,20 +77,20 @@ type payRequest struct {
 	SignType       string `xml:"sign_type,omitempty"`
 	Body           string `xml:"body"`
 	Detail         string `xml:"detail,omitempty"`
-	Attach         string `xml:"attach,omitempty"`      //附加数据
-	OutTradeNo     string `xml:"out_trade_no"`          //商户订单号
-	FeeType        string `xml:"fee_type,omitempty"`    //标价币种
-	TotalFee       string `xml:"total_fee"`             //标价金额
-	SpbillCreateIP string `xml:"spbill_create_ip"`      //终端IP
-	TimeStart      string `xml:"time_start,omitempty"`  //交易起始时间
-	TimeExpire     string `xml:"time_expire,omitempty"` //交易结束时间
-	GoodsTag       string `xml:"goods_tag,omitempty"`   //订单优惠标记
-	NotifyURL      string `xml:"notify_url"`            //通知地址
-	TradeType      string `xml:"trade_type"`            //交易类型
-	ProductID      string `xml:"product_id,omitempty"`  //商品ID
+	Attach         string `xml:"attach,omitempty"`      // 附加数据
+	OutTradeNo     string `xml:"out_trade_no"`          // 商户订单号
+	FeeType        string `xml:"fee_type,omitempty"`    // 标价币种
+	TotalFee       string `xml:"total_fee"`             // 标价金额
+	SpbillCreateIP string `xml:"spbill_create_ip"`      // 终端IP
+	TimeStart      string `xml:"time_start,omitempty"`  // 交易起始时间
+	TimeExpire     string `xml:"time_expire,omitempty"` // 交易结束时间
+	GoodsTag       string `xml:"goods_tag,omitempty"`   // 订单优惠标记
+	NotifyURL      string `xml:"notify_url"`            // 通知地址
+	TradeType      string `xml:"trade_type"`            // 交易类型
+	ProductID      string `xml:"product_id,omitempty"`  // 商品ID
 	LimitPay       string `xml:"limit_pay,omitempty"`   //
-	OpenID         string `xml:"openid,omitempty"`      //用户标识
-	SceneInfo      string `xml:"scene_info,omitempty"`  //场景信息
+	OpenID         string `xml:"openid,omitempty"`      // 用户标识
+	SceneInfo      string `xml:"scene_info,omitempty"`  // 场景信息
 }
 
 // NewPay return an instance of Pay package
@@ -153,7 +153,7 @@ func (pcf *Pay) PrePayOrder(p *Params) (payOrder PreOrder, err error) {
 	param["spbill_create_ip"] = p.CreateIP
 	param["total_fee"] = p.TotalFee
 	param["trade_type"] = p.TradeType
-	param["openid"] = p.OpenID
+	param["openid"] = p.OpenIDÒ
 	param["detail"] = p.Detail
 	param["attach"] = p.Attach
 	param["goods_tag"] = p.GoodsTag
@@ -192,7 +192,7 @@ func (pcf *Pay) PrePayOrder(p *Params) (payOrder PreOrder, err error) {
 		return
 	}
 	if payOrder.ReturnCode == "SUCCESS" {
-		//pay success
+		// pay success
 		if payOrder.ResultCode == "SUCCESS" {
 			err = nil
 			return

--- a/pay/pay.go
+++ b/pay/pay.go
@@ -110,9 +110,6 @@ func (pcf *Pay) BridgeConfig(p *Params) (cfg Config, err error) {
 	if err != nil {
 		return
 	}
-	if p.SignType == "" {
-		p.SignType = "MD5"
-	}
 	buffer.WriteString("appId=")
 	buffer.WriteString(order.AppID)
 	buffer.WriteString("&nonceStr=")
@@ -144,6 +141,15 @@ func (pcf *Pay) BridgeConfig(p *Params) (cfg Config, err error) {
 // PrePayOrder return data for invoke wechat payment
 func (pcf *Pay) PrePayOrder(p *Params) (payOrder PreOrder, err error) {
 	nonceStr := util.RandomStr(32)
+	notifyURL := pcf.PayNotifyURL
+	// 签名类型
+	if p.SignType == "" {
+		p.SignType = "MD5"
+	}
+	// 通知地址
+	if p.NotifyURL != "" {
+		notifyURL = p.NotifyURL
+	}
 	param := make(map[string]interface{})
 	param["appid"] = pcf.AppID
 	param["body"] = p.Body
@@ -153,19 +159,11 @@ func (pcf *Pay) PrePayOrder(p *Params) (payOrder PreOrder, err error) {
 	param["spbill_create_ip"] = p.CreateIP
 	param["total_fee"] = p.TotalFee
 	param["trade_type"] = p.TradeType
-	param["openid"] = p.OpenIDÒ
+	param["openid"] = p.OpenID
 	param["detail"] = p.Detail
 	param["attach"] = p.Attach
 	param["goods_tag"] = p.GoodsTag
-	param["notify_url"] = pcf.PayNotifyURL
-	// 签名类型
-	if p.SignType != "" {
-		param["sign_type"] = p.SignType
-	}
-	// 通知地址
-	if p.NotifyURL != "" {
-		param["notify_url"] = p.NotifyURL
-	}
+	param["notify_url"] = notifyURL
 
 	bizKey := "&key=" + pcf.PayKey
 	str := orderParam(param, bizKey)
@@ -179,9 +177,13 @@ func (pcf *Pay) PrePayOrder(p *Params) (payOrder PreOrder, err error) {
 		OutTradeNo:     p.OutTradeNo,
 		TotalFee:       p.TotalFee,
 		SpbillCreateIP: p.CreateIP,
-		NotifyURL:      pcf.PayNotifyURL,
+		NotifyURL:      notifyURL,
 		TradeType:      p.TradeType,
 		OpenID:         p.OpenID,
+		SignType:       p.SignType,
+		Detail:         p.Detail,
+		Attach:         p.Attach,
+		GoodsTag:       p.GoodsTag,
 	}
 	rawRet, err := util.PostXML(payGateway, request)
 	if err != nil {

--- a/pay/pay.go
+++ b/pay/pay.go
@@ -35,6 +35,10 @@ type Params struct {
 	OpenID     string
 	TradeType  string
 	SignType   string
+	Detail     string
+	Attach     string
+	GoodsTag   string
+	NotifyUrl  string
 }
 
 // Config 是传出用于 js sdk 用的参数
@@ -145,12 +149,23 @@ func (pcf *Pay) PrePayOrder(p *Params) (payOrder PreOrder, err error) {
 	param["body"] = p.Body
 	param["mch_id"] = pcf.PayMchID
 	param["nonce_str"] = nonceStr
-	param["notify_url"] = pcf.PayNotifyURL
 	param["out_trade_no"] = p.OutTradeNo
 	param["spbill_create_ip"] = p.CreateIP
 	param["total_fee"] = p.TotalFee
 	param["trade_type"] = p.TradeType
 	param["openid"] = p.OpenID
+	param["detail"] = p.Detail
+	param["attach"] = p.Attach
+	param["goods_tag"] = p.GoodsTag
+	param["notify_url"] = pcf.PayNotifyURL
+	// 签名类型
+	if p.SignType != "" {
+		param["sign_type"] = p.SignType
+	}
+	// 通知地址
+	if p.NotifyUrl != "" {
+		param["notify_url"] = p.NotifyUrl
+	}
 
 	bizKey := "&key=" + pcf.PayKey
 	str := orderParam(param, bizKey)

--- a/pay/pay.go
+++ b/pay/pay.go
@@ -160,6 +160,7 @@ func (pcf *Pay) PrePayOrder(p *Params) (payOrder PreOrder, err error) {
 	param["total_fee"] = p.TotalFee
 	param["trade_type"] = p.TradeType
 	param["openid"] = p.OpenID
+	param["sign_type"] = p.SignType
 	param["detail"] = p.Detail
 	param["attach"] = p.Attach
 	param["goods_tag"] = p.GoodsTag


### PR DESCRIPTION
之前的支付方法，只有统一下单的方法，统一下单后获得prepay id，但是没有签名数据，本次增加了 js 支付参数的方法，还有一些方法（app支付，扫码，等支付方式）需完善


 本地调用测试，小程序支付正常