### PR TITLE
fix: 序列化 xml 时添加 cdata 标签

### DIFF
--- a/message/message.go
+++ b/message/message.go
@@ -187,7 +187,7 @@ type CommonToken struct {
 // CDATA  使用该类型,在序列化为 xml 文本时文本会被解析器忽略
 type CDATA string
 
-//  MarshalXML 实现自己的序列化方法
+// MarshalXML 实现自己的序列化方法
 func (c CDATA) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return e.EncodeElement(struct {
 		string `xml:",cdata"`

--- a/message/message.go
+++ b/message/message.go
@@ -148,10 +148,10 @@ type MixMessage struct {
 	UnionID             string `xml:"UnionId"`
 
 	// 内容审核相关
-	IsRisky 		    bool `xml:"isrisky"`
-	ExtraInfoJSON 		string `xml:"extra_info_json"`
-	TraceID 			string `xml:"trace_id"`
-	StatusCode          int `xml:"status_code"`
+	IsRisky       bool   `xml:"isrisky"`
+	ExtraInfoJSON string `xml:"extra_info_json"`
+	TraceID       string `xml:"trace_id"`
+	StatusCode    int    `xml:"status_code"`
 }
 
 //EventPic 发图事件推送
@@ -178,20 +178,28 @@ type ResponseEncryptedXMLMsg struct {
 // CommonToken 消息中通用的结构
 type CommonToken struct {
 	XMLName      xml.Name `xml:"xml"`
-	ToUserName   string   `xml:"ToUserName"`
-	FromUserName string   `xml:"FromUserName"`
+	ToUserName   CDATA    `xml:"ToUserName"`
+	FromUserName CDATA    `xml:"FromUserName"`
 	CreateTime   int64    `xml:"CreateTime"`
 	MsgType      MsgType  `xml:"MsgType"`
 }
 
+type CDATA string
+
+func (c CDATA) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return e.EncodeElement(struct {
+		string `xml:",cdata"`
+	}{string(c)}, start)
+}
+
 //SetToUserName set ToUserName
 func (msg *CommonToken) SetToUserName(toUserName string) {
-	msg.ToUserName = toUserName
+	msg.ToUserName = CDATA(toUserName)
 }
 
 //SetFromUserName set FromUserName
 func (msg *CommonToken) SetFromUserName(fromUserName string) {
-	msg.FromUserName = fromUserName
+	msg.FromUserName = CDATA(fromUserName)
 }
 
 //SetCreateTime set createTime

--- a/message/message.go
+++ b/message/message.go
@@ -184,6 +184,7 @@ type CommonToken struct {
 	MsgType      MsgType  `xml:"MsgType"`
 }
 
+// CDATA  使用该类型,在序列化为 xml 文本时文本会被解析器忽略
 type CDATA string
 
 func (c CDATA) MarshalXML(e *xml.Encoder, start xml.StartElement) error {

--- a/message/message.go
+++ b/message/message.go
@@ -187,6 +187,7 @@ type CommonToken struct {
 // CDATA  使用该类型,在序列化为 xml 文本时文本会被解析器忽略
 type CDATA string
 
+//  MarshalXML 实现自己的序列化方法
 func (c CDATA) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return e.EncodeElement(struct {
 		string `xml:",cdata"`

--- a/message/text.go
+++ b/message/text.go
@@ -3,12 +3,12 @@ package message
 //Text 文本消息
 type Text struct {
 	CommonToken
-	Content string `xml:"Content"`
+	Content CDATA `xml:"Content"`
 }
 
 //NewText 初始化文本消息
 func NewText(content string) *Text {
 	text := new(Text)
-	text.Content = content
+	text.Content = CDATA(content)
 	return text
 }


### PR DESCRIPTION
## 改动目的
- 根据官方文档需要添加 cdata 标签
- 由于文本内容是超链接,开发或者测试时发现content字段被转义误认为是bug
- 更加规范