### PR TITLE
Update menu.go

### DIFF
--- a/officialaccount/menu/menu.go
+++ b/officialaccount/menu/menu.go
@@ -102,7 +102,7 @@ type ButtonNew struct {
 
 //MatchRule 个性化菜单规则
 type MatchRule struct {
-	GroupID            int32  `json:"group_id,omitempty"`
+	GroupID            string  `json:"group_id,omitempty"`
 	Sex                int32  `json:"sex,omitempty"`
 	Country            string `json:"country,omitempty"`
 	Province           string `json:"province,omitempty"`

--- a/officialaccount/menu/menu.go
+++ b/officialaccount/menu/menu.go
@@ -103,11 +103,11 @@ type ButtonNew struct {
 //MatchRule 个性化菜单规则
 type MatchRule struct {
 	GroupID            string  `json:"group_id,omitempty"`
-	Sex                int32  `json:"sex,omitempty"`
+	Sex                string  `json:"sex,omitempty"`
 	Country            string `json:"country,omitempty"`
 	Province           string `json:"province,omitempty"`
 	City               string `json:"city,omitempty"`
-	ClientPlatformType int32  `json:"client_platform_type,omitempty"`
+	ClientPlatformType string  `json:"client_platform_type,omitempty"`
 	Language           string `json:"language,omitempty"`
 }
 


### PR DESCRIPTION
json: cannot unmarshal string into Go struct field MatchRule.conditionalmenu.matchrule.group_id of type int32
接口返回是字符串
"matchrule": {
"group_id": "2"
}

结构体定义
//MatchRule 个性化菜单规则
type MatchRule struct {
GroupID int32 json:"group_id,omitempty"
...
}