### PR TITLE
fix:can not init offiaccount without cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/silenceper/wechat/v2
+module github.com/JaxSONG/wechat/v2
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
 	github.com/fatih/structs v1.1.0
 	github.com/gomodule/redigo v1.8.1
+	github.com/silenceper/wechat/v2 v2.0.1
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cast v1.3.1
 	github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,9 @@ github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/silenceper/wechat v1.2.6 h1:FED3ko2yD96YD153xIV0I0bDjII4GxWaggjsYKdjQQc=
+github.com/silenceper/wechat/v2 v2.0.1 h1:Gm4gtps+0tHhm1Kl88RhAcGmGAM3CqVvsK6rIX9ADR0=
+github.com/silenceper/wechat/v2 v2.0.1/go.mod h1:hksYXWXGl7/E6TQojFNgxv8ouTF9CPPjfvWWJouJJGs=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=

--- a/miniprogram/miniprogram.go
+++ b/miniprogram/miniprogram.go
@@ -27,6 +27,14 @@ func NewMiniProgram(cfg *config.Config) *MiniProgram {
 	return &MiniProgram{ctx}
 }
 
+func NewMiniProgramWithAkHandle(cfg *config.Config, ak credential.AccessTokenHandle) *MiniProgram {
+	ctx := &context.Context{
+		Config:            cfg,
+		AccessTokenHandle: ak,
+	}
+	return &MiniProgram{ctx}
+}
+
 //SetAccessTokenHandle 自定义access_token获取方式
 func (miniProgram *MiniProgram) SetAccessTokenHandle(accessTokenHandle credential.AccessTokenHandle) {
 	miniProgram.ctx.AccessTokenHandle = accessTokenHandle

--- a/officialaccount/officialaccount.go
+++ b/officialaccount/officialaccount.go
@@ -35,6 +35,14 @@ func NewOfficialAccount(cfg *config.Config) *OfficialAccount {
 	return &OfficialAccount{ctx: ctx}
 }
 
+func NewOfficialAccountWithAkHandle(cfg *config.Config, ak credential.AccessTokenHandle) *OfficialAccount {
+	ctx := &context.Context{
+		Config:            cfg,
+		AccessTokenHandle: ak,
+	}
+	return &OfficialAccount{ctx: ctx}
+}
+
 //SetAccessTokenHandle 自定义access_token获取方式
 func (officialAccount *OfficialAccount) SetAccessTokenHandle(accessTokenHandle credential.AccessTokenHandle) {
 	officialAccount.ctx.AccessTokenHandle = accessTokenHandle


### PR DESCRIPTION
```
//NewDefaultAccessToken new DefaultAccessToken
func NewDefaultAccessToken(appID, appSecret, cacheKeyPrefix string, cache cache.Cache) AccessTokenHandle {
	if cache == nil {
		panic("cache is ineed")
	}
	return &DefaultAccessToken{
		appID:           appID,
		appSecret:       appSecret,
		cache:           cache,
		cacheKeyPrefix:  cacheKeyPrefix,
		accessTokenLock: new(sync.Mutex),
	}
}
```
NewDefaultAccessToken will panic when cache is nil
