### PR TITLE
fix(platform): 修复jsTicket使用了错误的appID的问题.

### DIFF
--- a/openplatform/officialaccount/js/js.go
+++ b/openplatform/officialaccount/js/js.go
@@ -16,10 +16,10 @@ type Js struct {
 }
 
 //NewJs init
-func NewJs(context *context.Context) *Js {
+func NewJs(context *context.Context, appID string) *Js {
 	js := new(Js)
 	js.Context = context
-	jsTicketHandle := credential.NewDefaultJsTicket(context.AppID, credential.CacheKeyOfficialAccountPrefix, context.Cache)
+	jsTicketHandle := credential.NewDefaultJsTicket(appID, credential.CacheKeyOfficialAccountPrefix, context.Cache)
 	js.SetJsTicketHandle(jsTicketHandle)
 	return js
 }

--- a/openplatform/officialaccount/officialaccount.go
+++ b/openplatform/officialaccount/officialaccount.go
@@ -37,7 +37,7 @@ func (officialAccount *OfficialAccount) PlatformOauth() *oauth.Oauth {
 
 // PlatformJs 平台代获取js-sdk配置
 func (officialAccount *OfficialAccount) PlatformJs() *js.Js {
-	return js.NewJs(officialAccount.GetContext())
+	return js.NewJs(officialAccount.GetContext(), officialAccount.appID)
 }
 
 //DefaultAuthrAccessToken 默认获取授权ak的方法


### PR DESCRIPTION
而第三方平台开发者代替公众号使用 JS SDK 的步骤如下：
1、在申请第三方平台时填写的网页开发域名，将作为旗下授权公众号的 JS SDK 安全域名（详情见“接入前必读”-“申请资料说明”）
2、在第三方平台的网页中正常引入 JS 文件
3、通过 config 接口注入权限验证配置，但在获取 jsapi_ticket 时，不通过公众号的 access_token 来获取，而是通过第三方平台的授权公众号 token（公众号授权给第三方平台后，第三方平台通过“接口说明”中的 api_authorizer_token 接口得到的 token），来获取 jsapi_ticket，然后使用这个 jsapi_ticket 来得到 signature，进行 JS SDK 的配置和开发。**注意 JS SDK 的其他配置中，其他信息均为正常的公众号的资料（而非第三方平台的）**。
4、通过 ready 接口处理成功验证
5、通过 error 接口处理失败验证

fix: #329.