### PR TITLE
fix: 微信群发预览接口: 只支持单个OpenID

### DIFF
--- a/officialaccount/broadcast/broadcast.go
+++ b/officialaccount/broadcast/broadcast.go
@@ -333,9 +333,11 @@ func (broadcast *Broadcast) chooseTagOrOpenID(user *User, req *sendRequest) (ret
 		sendURL = sendURLByTag
 	} else {
 		if broadcast.preview {
-			// 预览
-			req.ToUser = user.OpenID
-			sendURL = previewSendURL
+			// 预览 默认发给第一个用户
+			if len(user.OpenID) != 0 {
+				req.ToUser = user.OpenID[0]
+				sendURL = previewSendURL
+			}
 		} else {
 			if user.TagID != 0 {
 				req.Filter = map[string]interface{}{


### PR DESCRIPTION
微信群发预览接口：只支持单个OpenID ,默认发给第一个用户
PS：使用openID slice 发送预览会失败
[接口文档](https://developers.weixin.qq.com/doc/offiaccount/Message_Management/Batch_Sends_and_Originality_Checks.html#8)
![image](https://user-images.githubusercontent.com/5516080/115118924-58699980-9fd8-11eb-97ff-f2014270514f.png)

