### PR TITLE
feat: 优化MixMessage采用指针传参，减少2次拷贝

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ officialAccount := wc.GetOfficialAccount(cfg)
 // 传入request和responseWriter
 server := officialAccount.GetServer(req, rw)
 //设置接收消息的处理方法
-server.SetMessageHandler(func(msg message.MixMessage) *message.Reply {
+server.SetMessageHandler(func(msg *message.MixMessage) *message.Reply {
 
     //回复消息：演示回复用户发送的消息
     text := message.NewText(msg.Content)

--- a/officialaccount/server/server.go
+++ b/officialaccount/server/server.go
@@ -27,10 +27,10 @@ type Server struct {
 
 	openID string
 
-	messageHandler func(message.MixMessage) *message.Reply
+	messageHandler func(*message.MixMessage) *message.Reply
 
 	RequestRawXMLMsg  []byte
-	RequestMsg        message.MixMessage
+	RequestMsg        *message.MixMessage
 	ResponseRawXMLMsg []byte
 	ResponseMsg       interface{}
 
@@ -105,7 +105,7 @@ func (srv *Server) handleRequest() (reply *message.Reply, err error) {
 	if err != nil {
 		return
 	}
-	mixMessage, success := msg.(message.MixMessage)
+	mixMessage, success := msg.(*message.MixMessage)
 	if !success {
 		err = errors.New("消息类型转换失败")
 	}
@@ -160,14 +160,14 @@ func (srv *Server) getMessage() (interface{}, error) {
 	return srv.parseRequestMessage(rawXMLMsgBytes)
 }
 
-func (srv *Server) parseRequestMessage(rawXMLMsgBytes []byte) (msg message.MixMessage, err error) {
-	msg = message.MixMessage{}
-	err = xml.Unmarshal(rawXMLMsgBytes, &msg)
+func (srv *Server) parseRequestMessage(rawXMLMsgBytes []byte) (msg *message.MixMessage, err error) {
+	msg = &message.MixMessage{}
+	err = xml.Unmarshal(rawXMLMsgBytes, msg)
 	return
 }
 
 //SetMessageHandler 设置用户自定义的回调方法
-func (srv *Server) SetMessageHandler(handler func(message.MixMessage) *message.Reply) {
+func (srv *Server) SetMessageHandler(handler func(*message.MixMessage) *message.Reply) {
 	srv.messageHandler = handler
 }
 

--- a/openplatform/README.md
+++ b/openplatform/README.md
@@ -22,7 +22,7 @@ openPlatform := wc.GetOpenPlatform(cfg)
 // 传入request和responseWriter
 server := openPlatform.GetServer(req, rw)
 //设置接收消息的处理方法
-server.SetMessageHandler(func(msg message.MixMessage) *message.Reply {
+server.SetMessageHandler(func(msg *message.MixMessage) *message.Reply {
     if msg.InfoType == message.InfoTypeVerifyTicket {
         componentVerifyTicket, err := openPlatform.SetComponentAccessToken(msg.ComponentVerifyTicket)
         if err != nil {


### PR DESCRIPTION
考虑到 MixMessage 是一个比较大的结构体 ( `896 bytes`)，看是否可以改用 Pointer 方式传参？
**好处：**

>可以减少2次copy
1 server.go:112  `srv.RequestMsg = mixMessage` 有一次copy
2 messageHandler 入参，有一次copy

**不足：**
接口兼容性：messageHandler 声明改为 
> func(*message.MixMessage) *message.Reply
