### PR TITLE
增加公众号订阅通知事件推送

### DIFF
--- a/officialaccount/message/message.go
+++ b/officialaccount/message/message.go
@@ -73,6 +73,8 @@ const (
 	EventMassSendJobFinish = "MASSSENDJOBFINISH"
 	// EventWxaMediaCheck 异步校验图片/音频是否含有违法违规内容推送事件
 	EventWxaMediaCheck = "wxa_media_check"
+	// EventSubscribeMsgPopupEvent 订阅通知事件推送
+	EventSubscribeMsgPopupEvent = "subscribe_msg_popup_event"
 )
 
 const (
@@ -144,6 +146,10 @@ type MixMessage struct {
 		Poiname   string  `xml:"Poiname"`
 	}
 
+	SubscribeMsgPopupEvent []struct {
+		List SubscribeMsgPopupEvent `xml:"List"`
+	} `xml:"SubscribeMsgPopupEvent"`
+
 	// 第三方平台相关
 	InfoType                     InfoType `xml:"InfoType"`
 	AppID                        string   `xml:"AppId"`
@@ -181,6 +187,13 @@ type MixMessage struct {
 
 	// 设备相关
 	device.MsgDevice
+}
+
+// SubscribeMsgPopupEvent 订阅通知事件推送的消息体
+type SubscribeMsgPopupEvent struct {
+	TemplateID            string `xml:"TemplateId"`
+	SubscribeStatusString string `xml:"SubscribeStatusString"`
+	PopupScene            int    `xml:"PopupScene"`
 }
 
 // EventPic 发图事件推送


### PR DESCRIPTION
官方文档 : https://developers.weixin.qq.com/doc/offiaccount/Subscription_Messages/api.html#%E4%BA%8B%E4%BB%B6%E6%8E%A8%E9%80%81


增加了什么?

1. EventType 类型增加 subscribe_msg_popup_event  订阅通知事件推送
2. MixMessage 消息体增加 SubscribeMsgPopupEvent 订阅通知事件参数