### PR TITLE
Bug fix: `omitempty`关键字，给它赋的值恰好等于默认空值的话，在转为 json 之后也不会输出这个 field

### DIFF
--- a/miniprogram/qrcode/qrcode.go
+++ b/miniprogram/qrcode/qrcode.go
@@ -40,17 +40,17 @@ type QRCoder struct {
 	Page string `json:"page,omitempty"`
 	// path 扫码进入的小程序页面路径
 	Path string `json:"path,omitempty"`
-	// checkPath 检查page 是否存在，为 true 时 page 必须是已经发布的小程序存在的页面（否则报错）；为 false 时允许小程序未发布或者 page 不存在， 但page 有数量上限（60000个）请勿滥用
-	CheckPath bool `json:"check_path,omitempty"`
+	// checkPath 检查page 是否存在，为 true 时 page 必须是已经发布的小程序存在的页面（否则报错）；为 false 时允许小程序未发布或者 page 不存在， 但page 有数量上限（60000个）请勿滥用，默认true
+	CheckPath *bool `json:"check_path,omitempty"`
 	// width 图片宽度
 	Width int `json:"width,omitempty"`
 	// scene 最大32个可见字符，只支持数字，大小写英文以及部分特殊字符：!#$&'()*+,/:;=?@-._~，其它字符请自行编码为合法字符（因不支持%，中文无法使用 urlencode 处理，请使用其他编码方式）
 	Scene string `json:"scene,omitempty"`
-	// autoColor 自动配置线条颜色，如果颜色依然是黑色，则说明不建议配置主色调
+	// autoColor 自动配置线条颜色，如果颜色依然是黑色，则说明不建议配置主色调，默认false
 	AutoColor bool `json:"auto_color,omitempty"`
 	// lineColor AutoColor 为 false 时生效，使用 rgb 设置颜色 例如 {"r":"xxx","g":"xxx","b":"xxx"},十进制表示
-	LineColor Color `json:"line_color,omitempty"`
-	// isHyaline 是否需要透明底色
+	LineColor *Color `json:"line_color,omitempty"`
+	// isHyaline 是否需要透明底色，默认false
 	IsHyaline bool `json:"is_hyaline,omitempty"`
 	// envVersion 要打开的小程序版本。正式版为 "release"，体验版为 "trial"，开发版为 "develop"
 	EnvVersion string `json:"env_version,omitempty"`


### PR DESCRIPTION
`CheckPath` 这个字段默认是false，就算赋值了，只有true才能被json解析，这个是“omitempty” 关键字的

`LineColor`这个字段也是，如果直接给Color结构体，就算注明`omitempty`关键字也无用，需要指针，这样 Golang 就能知道一个指针的“空值”是多少了，否则面对一个我们自定义的结构， Golang 是猜不出我们想要的空值的

详情
<https://www.jianshu.com/p/a2ed0d23d1b0>