### PR TITLE
fix: 统一服务信息，公众号消息模板字段bug

### DIFF
--- a/miniprogram/subscribe/subscribe.go
+++ b/miniprogram/subscribe/subscribe.go
@@ -121,7 +121,7 @@ type UniformMessage struct {
 		URL         string `json:"url"`
 		Miniprogram struct {
 			Appid    string `json:"appid"`
-			Pagepath string `json:"pagepath"`
+			Pagepath string `json:"page"`
 		} `json:"miniprogram"`
 		Data map[string]*DataItem `json:"data"`
 	} `json:"mp_template_msg"`


### PR DESCRIPTION
使用`pagepath`会报错`UniformSend Error , errcode=40165 , errmsg=invalid weapp pagepath`