### PR TITLE
客服管理功能添加

### DIFF
--- a/doc/api/officialaccount.md
+++ b/doc/api/officialaccount.md
@@ -35,12 +35,14 @@
 
 | 名称             | 请求方式  | URL                                    | 是否已实现 | 使用方法 |
 | ---------------- | --------- | -------------------------------------- | ---------- | -------- |
-| 获取客服基本信息 | GET       | /cgi-bin/customservice/getkflist       | NO         |          |
-| 添加客服帐号     | POST      | /customservice/kfaccount/add           | NO         |          |
-| 邀请绑定客服帐号 | POST      | /customservice/kfaccount/inviteworker  | NO         |          |
-| 设置客服信息     | POST      | /customservice/kfaccount/update        | NO         |          |
-| 上传客服头像     | POST/FORM | /customservice/kfaccount/uploadheadimg | NO         |          |
-| 删除客服帐号     | GET       | /customservice/kfaccount/del           | NO         |          |
+| 获取客服基本信息 | GET       | /cgi-bin/customservice/getkflist       | YES       | (csm *CustomerServiceManager) List |
+| 添加客服帐号     | POST      | /customservice/kfaccount/add           | YES       | (csm *CustomerServiceManager) Add |
+| 邀请绑定客服帐号 | POST      | /customservice/kfaccount/inviteworker  | YES       | (csm *CustomerServiceManager) InviteBind |
+| 设置客服信息     | POST      | /customservice/kfaccount/update        | YES       | (csm *CustomerServiceManager) Update |
+| 上传客服头像     | POST/FORM | /customservice/kfaccount/uploadheadimg | YES       | (csm *CustomerServiceManager) UploadHeadImg |
+| 删除客服帐号     | POST      | /customservice/kfaccount/del           | YES       | (csm *CustomerServiceManager) Delete |
+| 获取在线客服     | POST      |  /cgi-bin/customservice/getonlinekflist| YES       | (csm *CustomerServiceManager) OnlineList |
+| 下发客服输入状态 | POST      |  /cgi-bin/message/custom/typing        | YES       | (csm *CustomerServiceManager) SendTypingStatus |
 
 #### 会话控制
 

--- a/doc/api/officialaccount.md
+++ b/doc/api/officialaccount.md
@@ -35,14 +35,14 @@
 
 | 名称             | 请求方式  | URL                                    | 是否已实现 | 使用方法 |
 | ---------------- | --------- | -------------------------------------- | ---------- | -------- |
-| 获取客服基本信息 | GET       | /cgi-bin/customservice/getkflist       | YES       | (csm *CustomerServiceManager) List |
-| 添加客服帐号     | POST      | /customservice/kfaccount/add           | YES       | (csm *CustomerServiceManager) Add |
-| 邀请绑定客服帐号 | POST      | /customservice/kfaccount/inviteworker  | YES       | (csm *CustomerServiceManager) InviteBind |
-| 设置客服信息     | POST      | /customservice/kfaccount/update        | YES       | (csm *CustomerServiceManager) Update |
-| 上传客服头像     | POST/FORM | /customservice/kfaccount/uploadheadimg | YES       | (csm *CustomerServiceManager) UploadHeadImg |
-| 删除客服帐号     | POST      | /customservice/kfaccount/del           | YES       | (csm *CustomerServiceManager) Delete |
-| 获取在线客服     | POST      |  /cgi-bin/customservice/getonlinekflist| YES       | (csm *CustomerServiceManager) OnlineList |
-| 下发客服输入状态 | POST      |  /cgi-bin/message/custom/typing        | YES       | (csm *CustomerServiceManager) SendTypingStatus |
+| 获取客服基本信息 | GET       | /cgi-bin/customservice/getkflist       | YES       | (csm *Manager) List |
+| 添加客服帐号     | POST      | /customservice/kfaccount/add           | YES       | (csm *Manager) Add |
+| 邀请绑定客服帐号 | POST      | /customservice/kfaccount/inviteworker  | YES       | (csm *Manager) InviteBind |
+| 设置客服信息     | POST      | /customservice/kfaccount/update        | YES       | (csm *Manager) Update |
+| 上传客服头像     | POST/FORM | /customservice/kfaccount/uploadheadimg | YES       | (csm *Manager) UploadHeadImg |
+| 删除客服帐号     | POST      | /customservice/kfaccount/del           | YES       | (csm *Manager) Delete |
+| 获取在线客服     | POST      |  /cgi-bin/customservice/getonlinekflist| YES       | (csm *Manager) OnlineList |
+| 下发客服输入状态 | POST      |  /cgi-bin/message/custom/typing        | YES       | (csm *Manager) SendTypingStatus |
 
 #### 会话控制
 

--- a/officialaccount/customerservice/manager.go
+++ b/officialaccount/customerservice/manager.go
@@ -1,7 +1,6 @@
 package customerservice
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/silenceper/wechat/v2/officialaccount/context"
@@ -54,6 +53,7 @@ type KeFuInfo struct {
 }
 
 type resKeFuList struct {
+	util.CommonError
 	KfList []*KeFuInfo `json:"kf_list"`
 }
 
@@ -71,9 +71,8 @@ func (csm *Manager) List() (customerServiceList []*KeFuInfo, err error) {
 		return
 	}
 	var res resKeFuList
-	err = json.Unmarshal(response, &res)
+	err = util.DecodeWithError(response, &res, "ListCustomerService")
 	if err != nil {
-		err = util.NewCommonError("ListCustomerService", -1, err.Error())
 		return
 	}
 	customerServiceList = res.KfList
@@ -89,6 +88,7 @@ type KeFuOnlineInfo struct {
 }
 
 type resKeFuOnlineList struct {
+	util.CommonError
 	KfOnlineList []*KeFuOnlineInfo `json:"kf_online_list"`
 }
 
@@ -106,9 +106,8 @@ func (csm *Manager) OnlineList() (customerServiceOnlineList []*KeFuOnlineInfo, e
 		return
 	}
 	var res resKeFuOnlineList
-	err = json.Unmarshal(response, &res)
+	err = util.DecodeWithError(response, &res, "ListOnlineCustomerService")
 	if err != nil {
-		err = util.NewCommonError("ListOnlineCustomerService", -1, err.Error())
 		return
 	}
 	customerServiceOnlineList = res.KfOnlineList

--- a/officialaccount/customerservice/manager.go
+++ b/officialaccount/customerservice/manager.go
@@ -29,20 +29,20 @@ const (
 	CancelTyping TypingStatus = "CancelTyping"
 )
 
-// CustomerServiceManager 客服管理者，可以管理客服
-type CustomerServiceManager struct {
+// Manager 客服管理者，可以管理客服
+type Manager struct {
 	*context.Context
 }
 
 // NewCustomerServiceManager 实例化客服管理
-func NewCustomerServiceManager(ctx *context.Context) *CustomerServiceManager {
-	csm := new(CustomerServiceManager)
+func NewCustomerServiceManager(ctx *context.Context) *Manager {
+	csm := new(Manager)
 	csm.Context = ctx
 	return csm
 }
 
-// CustomerServiceInfo 客服基本信息
-type CustomerServiceInfo struct {
+// KeFuInfo 客服基本信息
+type KeFuInfo struct {
 	KfAccount     string `json:"kf_account"`         // 完整客服帐号，格式为：帐号前缀@公众号微信号
 	KfNick        string `json:"kf_nick"`            // 客服昵称
 	KfID          int    `json:"kf_id"`              // 客服编号
@@ -53,12 +53,12 @@ type CustomerServiceInfo struct {
 	InviteStatus  string `json:"invite_status"`      // 邀请的状态，有等待确认“waiting”，被拒绝“rejected”， 过期“expired”
 }
 
-type resCustomerServiceList struct {
-	KfList []*CustomerServiceInfo `json:"kf_list"`
+type resKeFuList struct {
+	KfList []*KeFuInfo `json:"kf_list"`
 }
 
 // List 获取所有客服基本信息
-func (csm *CustomerServiceManager) List() (customerServiceList []*CustomerServiceInfo, err error) {
+func (csm *Manager) List() (customerServiceList []*KeFuInfo, err error) {
 	var accessToken string
 	accessToken, err = csm.GetAccessToken()
 	if err != nil {
@@ -70,7 +70,7 @@ func (csm *CustomerServiceManager) List() (customerServiceList []*CustomerServic
 	if err != nil {
 		return
 	}
-	var res resCustomerServiceList
+	var res resKeFuList
 	err = json.Unmarshal(response, &res)
 	if err != nil {
 		err = fmt.Errorf("%s Error , errcode=%d , errmsg=%s", "ListCustomerService", 0, err.Error())
@@ -80,20 +80,20 @@ func (csm *CustomerServiceManager) List() (customerServiceList []*CustomerServic
 	return
 }
 
-// CustomerServiceOnlineInfo 客服在线信息
-type CustomerServiceOnlineInfo struct {
+// KeFuOnlineInfo 客服在线信息
+type KeFuOnlineInfo struct {
 	KfAccount    string `json:"kf_account"`
 	Status       int    `json:"status"`
 	KfID         int    `json:"kf_id"`
 	AcceptedCase int    `json:"accepted_case"`
 }
 
-type resCustomerServiceOnlineList struct {
-	KfOnlineList []*CustomerServiceOnlineInfo `json:"kf_online_list"`
+type resKeFuOnlineList struct {
+	KfOnlineList []*KeFuOnlineInfo `json:"kf_online_list"`
 }
 
 // OnlineList 获取在线客服列表
-func (csm *CustomerServiceManager) OnlineList() (customerServiceOnlineList []*CustomerServiceOnlineInfo, err error) {
+func (csm *Manager) OnlineList() (customerServiceOnlineList []*KeFuOnlineInfo, err error) {
 	var accessToken string
 	accessToken, err = csm.GetAccessToken()
 	if err != nil {
@@ -105,7 +105,7 @@ func (csm *CustomerServiceManager) OnlineList() (customerServiceOnlineList []*Cu
 	if err != nil {
 		return
 	}
-	var res resCustomerServiceOnlineList
+	var res resKeFuOnlineList
 	err = json.Unmarshal(response, &res)
 	if err != nil {
 		err = fmt.Errorf("%s Error , errcode=%d , errmsg=%s", "ListCustomerService", 0, err.Error())
@@ -116,7 +116,7 @@ func (csm *CustomerServiceManager) OnlineList() (customerServiceOnlineList []*Cu
 }
 
 // Add 添加客服账号
-func (csm *CustomerServiceManager) Add(kfAccount, nickName string) (err error) {
+func (csm *Manager) Add(kfAccount, nickName string) (err error) {
 	// kfAccount：完整客服帐号，格式为：帐号前缀@公众号微信号，帐号前缀最多10个字符，必须是英文、数字字符或者下划线，后缀为公众号微信号，长度不超过30个字符
 	// nickName：客服昵称，最长16个字
 	// 参数此处均不做校验
@@ -143,7 +143,7 @@ func (csm *CustomerServiceManager) Add(kfAccount, nickName string) (err error) {
 }
 
 // Update 修改客服账号
-func (csm *CustomerServiceManager) Update(kfAccount, nickName string) (err error) {
+func (csm *Manager) Update(kfAccount, nickName string) (err error) {
 	var accessToken string
 	accessToken, err = csm.GetAccessToken()
 	if err != nil {
@@ -167,7 +167,7 @@ func (csm *CustomerServiceManager) Update(kfAccount, nickName string) (err error
 }
 
 // Delete 删除客服帐号
-func (csm *CustomerServiceManager) Delete(kfAccount string) (err error) {
+func (csm *Manager) Delete(kfAccount string) (err error) {
 	var accessToken string
 	accessToken, err = csm.GetAccessToken()
 	if err != nil {
@@ -189,7 +189,7 @@ func (csm *CustomerServiceManager) Delete(kfAccount string) (err error) {
 }
 
 // InviteBind 邀请绑定客服帐号和微信号
-func (csm *CustomerServiceManager) InviteBind(kfAccount, inviteWX string) (err error) {
+func (csm *Manager) InviteBind(kfAccount, inviteWX string) (err error) {
 	var accessToken string
 	accessToken, err = csm.GetAccessToken()
 	if err != nil {
@@ -213,7 +213,7 @@ func (csm *CustomerServiceManager) InviteBind(kfAccount, inviteWX string) (err e
 }
 
 // UploadHeadImg 上传客服头像
-func (csm *CustomerServiceManager) UploadHeadImg(kfAccount, fileName string) (err error) {
+func (csm *Manager) UploadHeadImg(kfAccount, fileName string) (err error) {
 	var accessToken string
 	accessToken, err = csm.GetAccessToken()
 	if err != nil {
@@ -230,7 +230,7 @@ func (csm *CustomerServiceManager) UploadHeadImg(kfAccount, fileName string) (er
 }
 
 //SendTypingStatus 下发客服输入状态给用户
-func (csm *CustomerServiceManager) SendTypingStatus(openid string, cmd TypingStatus) (err error) {
+func (csm *Manager) SendTypingStatus(openid string, cmd TypingStatus) (err error) {
 	var accessToken string
 	accessToken, err = csm.GetAccessToken()
 	if err != nil {

--- a/officialaccount/customerservice/manager.go
+++ b/officialaccount/customerservice/manager.go
@@ -1,0 +1,160 @@
+package customerservice
+
+import (
+	"fmt"
+
+	"github.com/silenceper/wechat/v2/officialaccount/context"
+	"github.com/silenceper/wechat/v2/util"
+)
+
+const (
+	customerServiceListURL       = "https://api.weixin.qq.com/cgi-bin/customservice/getkflist"
+	customerServiceAddURL        = "https://api.weixin.qq.com/customservice/kfaccount/add"
+	customerServiceUpdateURL     = "https://api.weixin.qq.com/customservice/kfaccount/update"
+	customerServiceDeleteURL     = "https://api.weixin.qq.com/customservice/kfaccount/del"
+	customerServiceInviteURL     = "https://api.weixin.qq.com/customservice/kfaccount/inviteworker"
+	customerServiceUploadHeadImg = "https://api.weixin.qq.com/customservice/kfaccount/uploadheadimg"
+)
+
+type CustomerServiceManager struct {
+	*context.Context
+}
+
+func NewCustomerServiceManager(ctx *context.Context) *CustomerServiceManager {
+	csm := new(CustomerServiceManager)
+	csm.Context = ctx
+	return csm
+}
+
+// CustomerServiceInfo 客服基本信息
+type CustomerServiceInfo struct {
+	KfAccount     string `json:"kf_account"`         // 完整客服帐号，格式为：帐号前缀@公众号微信号
+	KfNick        string `json:"kf_nick"`            // 客服昵称
+	KfID          string `json:"kf_id"`              // 客服编号
+	KfHeadImgUrl  string `json:"kf_headimgurl"`      // 客服头像
+	KfWX          string `json:"kf_wx"`              // 如果客服帐号已绑定了客服人员微信号， 则此处显示微信号
+	InviteWX      string `json:"invite_wx"`          // 如果客服帐号尚未绑定微信号，但是已经发起了一个绑定邀请， 则此处显示绑定邀请的微信号
+	InviteExpTime int    `json:"invite_expire_time"` // 如果客服帐号尚未绑定微信号，但是已经发起过一个绑定邀请， 邀请的过期时间，为unix 时间戳
+	InviteStatus  string `json:"invite_status"`      // 邀请的状态，有等待确认“waiting”，被拒绝“rejected”， 过期“expired”
+}
+
+type resCustomerServiceList struct {
+	KfList []*CustomerServiceInfo `json:"kf_list"`
+}
+
+// List 获取所有客服基本信息
+func (csm *CustomerServiceManager) List() (customerServiceList []*CustomerServiceInfo, err error) {
+	var accessToken string
+	accessToken, err = csm.GetAccessToken()
+	if err != nil {
+		return
+	}
+	uri := fmt.Sprintf("%s?access_token=%s", customerServiceListURL, accessToken)
+	var response []byte
+	response, err = util.HTTPGet(uri)
+	if err != nil {
+		return
+	}
+	var res resCustomerServiceList
+	err = util.DecodeWithError(response, &res, "ListCustomerService")
+	if err != nil {
+		return
+	}
+	customerServiceList = res.KfList
+	return
+}
+
+// Add 添加客服账号
+func (csm *CustomerServiceManager) Add(kfAccount, nickName string) (err error) {
+	// kfAccount：完整客服帐号，格式为：帐号前缀@公众号微信号，帐号前缀最多10个字符，必须是英文、数字字符或者下划线，后缀为公众号微信号，长度不超过30个字符
+	// nickName：客服昵称，最长16个字
+	// 参数此处均不做校验
+	var accessToken string
+	accessToken, err = csm.GetAccessToken()
+	if err != nil {
+		return
+	}
+	uri := fmt.Sprintf("%s?access_token=%s", customerServiceAddURL, accessToken)
+	data := struct {
+		KfAccount string `json:"kf_account"`
+		NickName  string `json:"nickname"`
+	}{
+		KfAccount: kfAccount,
+		NickName:  nickName,
+	}
+	var response []byte
+	response, err = util.PostJSON(uri, data)
+	if err != nil {
+		return
+	}
+	err = util.DecodeWithCommonError(response, "AddCustomerService")
+	return
+}
+
+// Update 修改客服账号
+func (csm *CustomerServiceManager) Update(kfAccount, nickName string) (err error) {
+	var accessToken string
+	accessToken, err = csm.GetAccessToken()
+	if err != nil {
+		return
+	}
+	uri := fmt.Sprintf("%s?access_token=%s", customerServiceUpdateURL, accessToken)
+	data := struct {
+		KfAccount string `json:"kf_account"`
+		NickName  string `json:"nickname"`
+	}{
+		KfAccount: kfAccount,
+		NickName:  nickName,
+	}
+	var response []byte
+	response, err = util.PostJSON(uri, data)
+	if err != nil {
+		return
+	}
+	err = util.DecodeWithCommonError(response, "UpdateCustomerService")
+	return
+}
+
+// Delete 删除客服帐号
+func (csm *CustomerServiceManager) Delete(kfAccount string) (err error) {
+	var accessToken string
+	accessToken, err = csm.GetAccessToken()
+	if err != nil {
+		return
+	}
+	uri := fmt.Sprintf("%s?access_token=%s", customerServiceDeleteURL, accessToken)
+	data := struct {
+		KfAccount string `json:"kf_account"`
+	}{
+		KfAccount: kfAccount,
+	}
+	var response []byte
+	response, err = util.PostJSON(uri, data)
+	if err != nil {
+		return
+	}
+	err = util.DecodeWithCommonError(response, "DeleteCustomerService")
+	return
+}
+
+// InviteBind 邀请绑定客服帐号和微信号
+func (csm *CustomerServiceManager) InviteBind(kfAccount, inviteWX string) (err error) {
+	var accessToken string
+	accessToken, err = csm.GetAccessToken()
+	if err != nil {
+		return
+	}
+	uri := fmt.Sprintf("%s?access_token=%s", customerServiceInviteURL, accessToken)
+	data := struct {
+		KfAccount string `json:"kf_account"`
+	}{
+		KfAccount: kfAccount,
+	}
+	var response []byte
+	response, err = util.PostJSON(uri, data)
+	if err != nil {
+		return
+	}
+	err = util.DecodeWithCommonError(response, "InviteBindCustomerService")
+	return
+}

--- a/officialaccount/customerservice/manager.go
+++ b/officialaccount/customerservice/manager.go
@@ -158,3 +158,20 @@ func (csm *CustomerServiceManager) InviteBind(kfAccount, inviteWX string) (err e
 	err = util.DecodeWithCommonError(response, "InviteBindCustomerService")
 	return
 }
+
+// UploadHeadImg 上传客服头像
+func (csm *CustomerServiceManager) UploadHeadImg(kfAccount, fileName string) (err error) {
+	var accessToken string
+	accessToken, err = csm.GetAccessToken()
+	if err != nil {
+		return
+	}
+	uri := fmt.Sprintf("%s?access_token=%s&kf_account=%s", customerServiceUploadHeadImg, accessToken, kfAccount)
+	var response []byte
+	response, err = util.PostFile("media", fileName, uri)
+	if err != nil {
+		return
+	}
+	err = util.DecodeWithCommonError(response, "UploadCustomerServiceHeadImg")
+	return
+}

--- a/officialaccount/customerservice/manager.go
+++ b/officialaccount/customerservice/manager.go
@@ -73,7 +73,7 @@ func (csm *Manager) List() (customerServiceList []*KeFuInfo, err error) {
 	var res resKeFuList
 	err = json.Unmarshal(response, &res)
 	if err != nil {
-		err = fmt.Errorf("%s Error , errcode=%d , errmsg=%s", "ListCustomerService", 0, err.Error())
+		err = util.NewCommonError("ListCustomerService", -1, err.Error())
 		return
 	}
 	customerServiceList = res.KfList
@@ -108,7 +108,7 @@ func (csm *Manager) OnlineList() (customerServiceOnlineList []*KeFuOnlineInfo, e
 	var res resKeFuOnlineList
 	err = json.Unmarshal(response, &res)
 	if err != nil {
-		err = fmt.Errorf("%s Error , errcode=%d , errmsg=%s", "ListCustomerService", 0, err.Error())
+		err = util.NewCommonError("ListOnlineCustomerService", -1, err.Error())
 		return
 	}
 	customerServiceOnlineList = res.KfOnlineList

--- a/officialaccount/customerservice/manager.go
+++ b/officialaccount/customerservice/manager.go
@@ -8,6 +8,7 @@ import (
 	"github.com/silenceper/wechat/v2/util"
 )
 
+// TypingStatus 输入状态类型
 type TypingStatus string
 
 const (
@@ -22,14 +23,18 @@ const (
 )
 
 const (
-	Typing       TypingStatus = "Typing"
+	// Typing 表示正在输入状态
+	Typing TypingStatus = "Typing"
+	// CancelTyping 表示取消正在输入状态
 	CancelTyping TypingStatus = "CancelTyping"
 )
 
+// CustomerServiceManager 客服管理者，可以管理客服
 type CustomerServiceManager struct {
 	*context.Context
 }
 
+// NewCustomerServiceManager 实例化客服管理
 func NewCustomerServiceManager(ctx *context.Context) *CustomerServiceManager {
 	csm := new(CustomerServiceManager)
 	csm.Context = ctx
@@ -41,7 +46,7 @@ type CustomerServiceInfo struct {
 	KfAccount     string `json:"kf_account"`         // 完整客服帐号，格式为：帐号前缀@公众号微信号
 	KfNick        string `json:"kf_nick"`            // 客服昵称
 	KfID          int    `json:"kf_id"`              // 客服编号
-	KfHeadImgUrl  string `json:"kf_headimgurl"`      // 客服头像
+	KfHeadImgURL  string `json:"kf_headimgurl"`      // 客服头像
 	KfWX          string `json:"kf_wx"`              // 如果客服帐号已绑定了客服人员微信号， 则此处显示微信号
 	InviteWX      string `json:"invite_wx"`          // 如果客服帐号尚未绑定微信号，但是已经发起了一个绑定邀请， 则此处显示绑定邀请的微信号
 	InviteExpTime int    `json:"invite_expire_time"` // 如果客服帐号尚未绑定微信号，但是已经发起过一个绑定邀请， 邀请的过期时间，为unix 时间戳
@@ -87,7 +92,7 @@ type resCustomerServiceOnlineList struct {
 	KfOnlineList []*CustomerServiceOnlineInfo `json:"kf_online_list"`
 }
 
-// ListOnline 获取在线客服列表
+// OnlineList 获取在线客服列表
 func (csm *CustomerServiceManager) OnlineList() (customerServiceOnlineList []*CustomerServiceOnlineInfo, err error) {
 	var accessToken string
 	accessToken, err = csm.GetAccessToken()

--- a/officialaccount/customerservice/manager.go
+++ b/officialaccount/customerservice/manager.go
@@ -8,6 +8,8 @@ import (
 	"github.com/silenceper/wechat/v2/util"
 )
 
+type TypingStatus string
+
 const (
 	customerServiceListURL       = "https://api.weixin.qq.com/cgi-bin/customservice/getkflist"
 	customerServiceOnlineListURL = "https://api.weixin.qq.com/cgi-bin/customservice/getonlinekflist"
@@ -16,6 +18,12 @@ const (
 	customerServiceDeleteURL     = "https://api.weixin.qq.com/customservice/kfaccount/del"
 	customerServiceInviteURL     = "https://api.weixin.qq.com/customservice/kfaccount/inviteworker"
 	customerServiceUploadHeadImg = "https://api.weixin.qq.com/customservice/kfaccount/uploadheadimg"
+	customerServiceTypingURL     = "https://api.weixin.qq.com/cgi-bin/message/custom/typing"
+)
+
+const (
+	Typing       TypingStatus = "Typing"
+	CancelTyping TypingStatus = "CancelTyping"
 )
 
 type CustomerServiceManager struct {
@@ -213,5 +221,29 @@ func (csm *CustomerServiceManager) UploadHeadImg(kfAccount, fileName string) (er
 		return
 	}
 	err = util.DecodeWithCommonError(response, "UploadCustomerServiceHeadImg")
+	return
+}
+
+//SendTypingStatus 下发客服输入状态给用户
+func (csm *CustomerServiceManager) SendTypingStatus(openid string, cmd TypingStatus) (err error) {
+	var accessToken string
+	accessToken, err = csm.GetAccessToken()
+	if err != nil {
+		return
+	}
+	uri := fmt.Sprintf("%s?access_token=%s", customerServiceTypingURL, accessToken)
+	data := struct {
+		ToUser  string `json:"touser"`
+		Command string `json:"command"`
+	}{
+		ToUser:  openid,
+		Command: string(cmd),
+	}
+	var response []byte
+	response, err = util.PostJSON(uri, data)
+	if err != nil {
+		return
+	}
+	err = util.DecodeWithCommonError(response, "SendTypingStatus")
 	return
 }

--- a/officialaccount/officialaccount.go
+++ b/officialaccount/officialaccount.go
@@ -14,6 +14,7 @@ import (
 	"github.com/silenceper/wechat/v2/officialaccount/broadcast"
 	"github.com/silenceper/wechat/v2/officialaccount/config"
 	"github.com/silenceper/wechat/v2/officialaccount/context"
+	"github.com/silenceper/wechat/v2/officialaccount/customerservice"
 	"github.com/silenceper/wechat/v2/officialaccount/device"
 	"github.com/silenceper/wechat/v2/officialaccount/js"
 	"github.com/silenceper/wechat/v2/officialaccount/material"
@@ -136,4 +137,9 @@ func (officialAccount *OfficialAccount) GetOCR() *ocr.OCR {
 // GetSubscribe 公众号订阅消息
 func (officialAccount *OfficialAccount) GetSubscribe() *message.Subscribe {
 	return message.NewSubscribe(officialAccount.ctx)
+}
+
+// GetCustomerServiceManager 客服管理
+func (officialAccount *OfficialAccount) GetCustomerServiceManager() *customerservice.CustomerServiceManager {
+	return customerservice.NewCustomerServiceManager(officialAccount.ctx)
 }

--- a/officialaccount/officialaccount.go
+++ b/officialaccount/officialaccount.go
@@ -140,6 +140,6 @@ func (officialAccount *OfficialAccount) GetSubscribe() *message.Subscribe {
 }
 
 // GetCustomerServiceManager 客服管理
-func (officialAccount *OfficialAccount) GetCustomerServiceManager() *customerservice.CustomerServiceManager {
+func (officialAccount *OfficialAccount) GetCustomerServiceManager() *customerservice.Manager {
 	return customerservice.NewCustomerServiceManager(officialAccount.ctx)
 }

--- a/officialaccount/server/server.go
+++ b/officialaccount/server/server.go
@@ -73,6 +73,11 @@ func (srv *Server) Serve() error {
 	if err != nil {
 		return err
 	}
+	// 非安全模式下，请求处理方法返回为nil则直接回复success给微信服务器
+	if response == nil && !srv.isSafeMode {
+		srv.String("success")
+		return nil
+	}
 
 	// debug print request msg
 	log.Debugf("request msg =%s", string(srv.RequestRawXMLMsg))

--- a/util/error.go
+++ b/util/error.go
@@ -17,6 +17,15 @@ func (c *CommonError) Error() string {
 	return fmt.Sprintf("%s Error , errcode=%d , errmsg=%s", c.apiName, c.ErrCode, c.ErrMsg)
 }
 
+// NewCommonError 新建CommonError错误，对于无errcode和errmsg的返回也可以返回该通用错误
+func NewCommonError(apiName string, code int64, msg string) *CommonError {
+	return &CommonError{
+		apiName: apiName,
+		ErrCode: code,
+		ErrMsg:  msg,
+	}
+}
+
 // DecodeWithCommonError 将返回值按照CommonError解析
 func DecodeWithCommonError(response []byte, apiName string) (err error) {
 	var commError CommonError


### PR DESCRIPTION
所有代码均自测通过；

官方文档有2处：
官方文档【1】链接：
https://developers.weixin.qq.com/doc/offiaccount/Customer_Service/Customer_Service_Management.html

官方文档【2】链接：
https://developers.weixin.qq.com/doc/offiaccount/Message_Management/Service_Center_messages.html

以上两处文档不同之处有几方面：
1中添加和更新客服不需要密码参数，2中有参数。代码采用1文档
1中删除客服账号使用get请求，2中使用post请求。代码采用2文档