### PR TITLE
mini 开发平台代小程序实现业务逻辑完善

### DIFF
--- a/openplatform/miniprogram/miniprogram.go
+++ b/openplatform/miniprogram/miniprogram.go
@@ -1,7 +1,7 @@
 package miniprogram
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/silenceper/wechat/v2/credential"
 	"github.com/silenceper/wechat/v2/miniprogram"
@@ -28,7 +28,7 @@ func (miniProgram *MiniProgram) GetAccessToken() (string, error) {
 		return ak, nil
 	}
 	if miniProgram.authorizerRefreshToken == "" {
-		return "", errors.New("please set the authorizer_refresh_token first")
+		return "", fmt.Errorf("please set the authorizer_refresh_token first")
 	}
 	akRes, akResErr := miniProgram.GetComponent().RefreshAuthrToken(miniProgram.AppID, miniProgram.authorizerRefreshToken)
 	if akResErr != nil {

--- a/openplatform/miniprogram/miniprogram.go
+++ b/openplatform/miniprogram/miniprogram.go
@@ -2,7 +2,9 @@ package miniprogram
 
 import (
 	"fmt"
-
+	"github.com/silenceper/wechat/v2/credential"
+	"github.com/silenceper/wechat/v2/miniprogram"
+	miniConfig "github.com/silenceper/wechat/v2/miniprogram/config"
 	miniContext "github.com/silenceper/wechat/v2/miniprogram/context"
 	"github.com/silenceper/wechat/v2/miniprogram/urllink"
 	openContext "github.com/silenceper/wechat/v2/openplatform/context"
@@ -14,7 +16,7 @@ import (
 type MiniProgram struct {
 	AppID       string
 	openContext *openContext.Context
-
+	*miniprogram.MiniProgram
 	authorizerRefreshToken string
 }
 
@@ -42,10 +44,13 @@ func (miniProgram *MiniProgram) SetAuthorizerRefreshToken(authorizerRefreshToken
 
 // NewMiniProgram 实例化
 func NewMiniProgram(opCtx *openContext.Context, appID string) *MiniProgram {
-	return &MiniProgram{
-		openContext: opCtx,
-		AppID:       appID,
-	}
+	miniProgram := miniprogram.NewMiniProgram(&miniConfig.Config{
+		AppID: opCtx.AppID,
+		Cache: opCtx.Cache,
+	})
+	// 设置获取access_token的函数
+	miniProgram.SetAccessTokenHandle(NewDefaultAuthrAccessToken(opCtx, appID))
+	return &MiniProgram{AppID: appID, MiniProgram: miniProgram, openContext: opCtx}
 }
 
 // GetComponent get component
@@ -64,4 +69,23 @@ func (miniProgram *MiniProgram) GetURLLink() *urllink.URLLink {
 	return urllink.NewURLLink(&miniContext.Context{
 		AccessTokenHandle: miniProgram,
 	})
+}
+
+// DefaultAuthrAccessToken 默认获取授权ak的方法
+type DefaultAuthrAccessToken struct {
+	opCtx *openContext.Context
+	appID string
+}
+
+// NewDefaultAuthrAccessToken New
+func NewDefaultAuthrAccessToken(opCtx *openContext.Context, appID string) credential.AccessTokenHandle {
+	return &DefaultAuthrAccessToken{
+		opCtx: opCtx,
+		appID: appID,
+	}
+}
+
+// GetAccessToken 获取ak
+func (ak *DefaultAuthrAccessToken) GetAccessToken() (string, error) {
+	return ak.opCtx.GetAuthrAccessToken(ak.appID)
 }

--- a/openplatform/miniprogram/miniprogram.go
+++ b/openplatform/miniprogram/miniprogram.go
@@ -1,7 +1,8 @@
 package miniprogram
 
 import (
-	"fmt"
+	"errors"
+
 	"github.com/silenceper/wechat/v2/credential"
 	"github.com/silenceper/wechat/v2/miniprogram"
 	miniConfig "github.com/silenceper/wechat/v2/miniprogram/config"
@@ -27,7 +28,7 @@ func (miniProgram *MiniProgram) GetAccessToken() (string, error) {
 		return ak, nil
 	}
 	if miniProgram.authorizerRefreshToken == "" {
-		return "", fmt.Errorf("please set the authorizer_refresh_token first")
+		return "", errors.New("please set the authorizer_refresh_token first")
 	}
 	akRes, akResErr := miniProgram.GetComponent().RefreshAuthrToken(miniProgram.AppID, miniProgram.authorizerRefreshToken)
 	if akResErr != nil {
@@ -77,7 +78,7 @@ type DefaultAuthrAccessToken struct {
 	appID string
 }
 
-// NewDefaultAuthrAccessToken New
+// NewDefaultAuthrAccessToken 设置access_token
 func NewDefaultAuthrAccessToken(opCtx *openContext.Context, appID string) credential.AccessTokenHandle {
 	return &DefaultAuthrAccessToken{
 		opCtx: opCtx,


### PR DESCRIPTION
开放平台代小程序实现业务（参考代公众号实现业务）

例如小程序登录代码实现

miniProgram := openPlatform.GetMiniProgram(appid)
number, err := miniProgram.GetAuth().GetPhoneNumber("code")