### PR TITLE
企业微信客户群进群方式配置(#631)

### DIFF
--- a/work/externalcontact/groupchat.go
+++ b/work/externalcontact/groupchat.go
@@ -8,6 +8,7 @@ import (
 const OpengidToChatid = "https://qyapi.weixin.qq.com/cgi-bin/externalcontact/opengid_to_chatid"
 
 type (
+	//GroupChatListRequest 获取客户群列表的请求参数
 	GroupChatListRequest struct {
 		StatusFilter int         `json:"status_filter"` // 非必填	客户群跟进状态过滤。0 - 所有列表(即不过滤) 1 - 离职待继承 2 - 离职继承中 3 - 离职继承完成
 		OwnerFilter  OwnerFilter `json:"owner_filter"`  //非必填	群主过滤。如果不填，表示获取应用可见范围内全部群主的数据（但是不建议这么用，如果可见范围人数超过1000人，为了防止数据包过大，会报错 81017）
@@ -15,15 +16,16 @@ type (
 		Limit        int         `json:"limit"`         //必填	分页，预期请求的数据量，取值范围 1 ~ 1000
 	}
 
+	//GroupChatList 客户群列表
 	GroupChatList struct {
-		ChatId string `json:"chat_id"`
+		ChatID string `json:"chat_id"`
 		Status int    `json:"status"`
 	}
-
+	//GroupChatListResponse 获取客户群列表的返回值
 	GroupChatListResponse struct {
 		util.CommonError
 		GroupChatList []GroupChatList `json:"group_chat_list"`
-		NextCursor    string          `json:"next_cursor"`
+		NextCursor    string          `json:"next_cursor"` //游标
 	}
 )
 
@@ -47,36 +49,40 @@ func (r *Client) GetGroupChatList(req *GroupChatListRequest) (*GroupChatListResp
 }
 
 type (
+	//GroupChatDetailRequest 客户群详情 请求参数
 	GroupChatDetailRequest struct {
-		ChatId   string `json:"chat_id"`
+		ChatID   string `json:"chat_id"`
 		NeedName int    `json:"need_name"`
 	}
+	//Invitor 邀请者
 	Invitor struct {
-		Userid string `json:"userid"` //邀请者的userid
+		UserID string `json:"userid"` //邀请者的userid
 	}
-	Member struct {
-		Userid        string  `json:"userid"`            //群成员id
+	//GroupChatMember 群成员
+	GroupChatMember struct {
+		UserID        string  `json:"userid"`            //群成员id
 		Type          int     `json:"type"`              //成员类型。 1 - 企业成员  2 - 外部联系人
 		JoinTime      int     `json:"join_time"`         //入群时间
 		JoinScene     int     `json:"join_scene"`        //入群方式 1 - 由群成员邀请入群（直接邀请入群） 2 - 由群成员邀请入群（通过邀请链接入群） 3 - 通过扫描群二维码入群
 		Invitor       Invitor `json:"invitor,omitempty"` //邀请者。目前仅当是由本企业内部成员邀请入群时会返回该值
 		GroupNickname string  `json:"group_nickname"`    //在群里的昵称
 		Name          string  `json:"name"`              //名字。仅当 need_name = 1 时返回 如果是微信用户，则返回其在微信中设置的名字 如果是企业微信联系人，则返回其设置对外展示的别名或实名
-		Unionid       string  `json:"unionid,omitempty"` //外部联系人在微信开放平台的唯一身份标识（微信unionid），通过此字段企业可将外部联系人与公众号/小程序用户关联起来。仅当群成员类型是微信用户（包括企业成员未添加好友），且企业绑定了微信开发者ID有此字段（查看绑定方法）。第三方不可获取，上游企业不可获取下游企业客户的unionid字段
+		UnionID       string  `json:"unionid,omitempty"` //外部联系人在微信开放平台的唯一身份标识（微信unionid），通过此字段企业可将外部联系人与公众号/小程序用户关联起来。仅当群成员类型是微信用户（包括企业成员未添加好友），且企业绑定了微信开发者ID有此字段（查看绑定方法）。第三方不可获取，上游企业不可获取下游企业客户的unionid字段
 	}
-	Admin struct {
-		Userid string `json:"userid"` //群管理员userid
+	//GroupChatAdmin 群管理员
+	GroupChatAdmin struct {
+		UserID string `json:"userid"` //群管理员userid
 	}
 	GroupChat struct { //客户群详情
-		ChatId     string   `json:"chat_id"`     //客户群ID
-		Name       string   `json:"name"`        //群名
-		Owner      string   `json:"owner"`       //群主ID
-		CreateTime int      `json:"create_time"` //群的创建时间
-		Notice     string   `json:"notice"`      //群公告
-		MemberList []Member `json:"member_list"` //群成员列表
-		AdminList  []Admin  `json:"admin_list"`  //群管理员列表
+		ChatID     string            `json:"chat_id"`     //客户群ID
+		Name       string            `json:"name"`        //群名
+		Owner      string            `json:"owner"`       //群主ID
+		CreateTime int               `json:"create_time"` //群的创建时间
+		Notice     string            `json:"notice"`      //群公告
+		MemberList []GroupChatMember `json:"member_list"` //群成员列表
+		AdminList  []GroupChatAdmin  `json:"admin_list"`  //群管理员列表
 	}
-
+	//GroupChatDetailResponse 客户群详情 返回值
 	GroupChatDetailResponse struct {
 		util.CommonError
 		GroupChat GroupChat `json:"group_chat"` //客户群详情
@@ -103,18 +109,20 @@ func (r *Client) GetGroupChatDetail(req *GroupChatDetailRequest) (*GroupChatDeta
 }
 
 type (
-	OpengidToChatidRequest struct {
-		Opengid string `json:"opengid"`
+	//OpengIDToChatIDRequest 客户群opengid转换 请求参数
+	OpengIDToChatIDRequest struct {
+		OpengID string `json:"opengid"`
 	}
-	OpengidToChatidResponse struct {
+	//OpengIDToChatIDResponse 客户群opengid转换 返回值
+	OpengIDToChatIDResponse struct {
 		util.CommonError
-		ChatId string `json:"chat_id"` //客户群ID
+		ChatID string `json:"chat_id"` //客户群ID
 	}
 )
 
 // OpengidToChatid 客户群opengid转换
 // @see https://developer.work.weixin.qq.com/document/path/94822
-func (r *Client) OpengidToChatid(req *OpengidToChatidRequest) (*OpengidToChatidResponse, error) {
+func (r *Client) OpengidToChatid(req *OpengIDToChatIDRequest) (*OpengIDToChatIDResponse, error) {
 	accessToken, err := r.GetAccessToken()
 	if err != nil {
 		return nil, err
@@ -124,7 +132,7 @@ func (r *Client) OpengidToChatid(req *OpengidToChatidRequest) (*OpengidToChatidR
 	if err != nil {
 		return nil, err
 	}
-	result := &OpengidToChatidResponse{}
+	result := &OpengIDToChatIDResponse{}
 	if err = util.DecodeWithError(response, result, "GetGroupChatDetail"); err != nil {
 		return nil, err
 	}

--- a/work/externalcontact/groupchat.go
+++ b/work/externalcontact/groupchat.go
@@ -2,11 +2,11 @@ package externalcontact
 
 import (
 	"fmt"
-	
+
 	"github.com/silenceper/wechat/v2/util"
 )
 
-// OpengIDToChatIDURL .
+// OpengIDToChatIDURL 客户群opengid转换URL
 const OpengIDToChatIDURL = "https://qyapi.weixin.qq.com/cgi-bin/externalcontact/opengid_to_chatid"
 
 type (
@@ -124,7 +124,7 @@ type (
 )
 
 // OpengIDToChatID 客户群opengid转换
-// @see https://developer.work.weixin.qq.com/document/path/94822
+// @see https://developer.work.weixin.qq.com/document/path/94828
 func (r *Client) OpengIDToChatID(req *OpengIDToChatIDRequest) (*OpengIDToChatIDResponse, error) {
 	accessToken, err := r.GetAccessToken()
 	if err != nil {

--- a/work/externalcontact/groupchat.go
+++ b/work/externalcontact/groupchat.go
@@ -2,9 +2,11 @@ package externalcontact
 
 import (
 	"fmt"
+	
 	"github.com/silenceper/wechat/v2/util"
 )
 
+// OpengIDToChatIDURL .
 const OpengIDToChatIDURL = "https://qyapi.weixin.qq.com/cgi-bin/externalcontact/opengid_to_chatid"
 
 type (

--- a/work/externalcontact/groupchat.go
+++ b/work/externalcontact/groupchat.go
@@ -5,7 +5,7 @@ import (
 	"github.com/silenceper/wechat/v2/util"
 )
 
-const OpengidToChatid = "https://qyapi.weixin.qq.com/cgi-bin/externalcontact/opengid_to_chatid"
+const OpengIDToChatIDURL = "https://qyapi.weixin.qq.com/cgi-bin/externalcontact/opengid_to_chatid"
 
 type (
 	//GroupChatListRequest 获取客户群列表的请求参数
@@ -73,7 +73,8 @@ type (
 	GroupChatAdmin struct {
 		UserID string `json:"userid"` //群管理员userid
 	}
-	GroupChat struct { //客户群详情
+	//GroupChat 客户群详情
+	GroupChat struct {
 		ChatID     string            `json:"chat_id"`     //客户群ID
 		Name       string            `json:"name"`        //群名
 		Owner      string            `json:"owner"`       //群主ID
@@ -120,15 +121,15 @@ type (
 	}
 )
 
-// OpengidToChatid 客户群opengid转换
+// OpengIDToChatID 客户群opengid转换
 // @see https://developer.work.weixin.qq.com/document/path/94822
-func (r *Client) OpengidToChatid(req *OpengIDToChatIDRequest) (*OpengIDToChatIDResponse, error) {
+func (r *Client) OpengIDToChatID(req *OpengIDToChatIDRequest) (*OpengIDToChatIDResponse, error) {
 	accessToken, err := r.GetAccessToken()
 	if err != nil {
 		return nil, err
 	}
 	var response []byte
-	response, err = util.PostJSON(fmt.Sprintf("%s?access_token=%s", OpengidToChatid, accessToken), req)
+	response, err = util.PostJSON(fmt.Sprintf("%s?access_token=%s", OpengIDToChatIDURL, accessToken), req)
 	if err != nil {
 		return nil, err
 	}

--- a/work/externalcontact/groupchat.go
+++ b/work/externalcontact/groupchat.go
@@ -1,0 +1,132 @@
+package externalcontact
+
+import (
+	"fmt"
+	"github.com/silenceper/wechat/v2/util"
+)
+
+const OpengidToChatid = "https://qyapi.weixin.qq.com/cgi-bin/externalcontact/opengid_to_chatid"
+
+type (
+	GroupChatListRequest struct {
+		StatusFilter int         `json:"status_filter"` // 非必填	客户群跟进状态过滤。0 - 所有列表(即不过滤) 1 - 离职待继承 2 - 离职继承中 3 - 离职继承完成
+		OwnerFilter  OwnerFilter `json:"owner_filter"`  //非必填	群主过滤。如果不填，表示获取应用可见范围内全部群主的数据（但是不建议这么用，如果可见范围人数超过1000人，为了防止数据包过大，会报错 81017）
+		Cursor       string      `json:"cursor"`        //非必填	用于分页查询的游标，字符串类型，由上一次调用返回，首次调用不填
+		Limit        int         `json:"limit"`         //必填	分页，预期请求的数据量，取值范围 1 ~ 1000
+	}
+
+	GroupChatList struct {
+		ChatId string `json:"chat_id"`
+		Status int    `json:"status"`
+	}
+
+	GroupChatListResponse struct {
+		util.CommonError
+		GroupChatList []GroupChatList `json:"group_chat_list"`
+		NextCursor    string          `json:"next_cursor"`
+	}
+)
+
+// GetGroupChatList 获取客户群列表
+// @see https://developer.work.weixin.qq.com/document/path/92120
+func (r *Client) GetGroupChatList(req *GroupChatListRequest) (*GroupChatListResponse, error) {
+	accessToken, err := r.GetAccessToken()
+	if err != nil {
+		return nil, err
+	}
+	var response []byte
+	response, err = util.PostJSON(fmt.Sprintf("%s/list?access_token=%s", GroupChatURL, accessToken), req)
+	if err != nil {
+		return nil, err
+	}
+	result := &GroupChatListResponse{}
+	if err = util.DecodeWithError(response, result, "GetGroupChatList"); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+type (
+	GroupChatDetailRequest struct {
+		ChatId   string `json:"chat_id"`
+		NeedName int    `json:"need_name"`
+	}
+	Invitor struct {
+		Userid string `json:"userid"` //邀请者的userid
+	}
+	Member struct {
+		Userid        string  `json:"userid"`            //群成员id
+		Type          int     `json:"type"`              //成员类型。 1 - 企业成员  2 - 外部联系人
+		JoinTime      int     `json:"join_time"`         //入群时间
+		JoinScene     int     `json:"join_scene"`        //入群方式 1 - 由群成员邀请入群（直接邀请入群） 2 - 由群成员邀请入群（通过邀请链接入群） 3 - 通过扫描群二维码入群
+		Invitor       Invitor `json:"invitor,omitempty"` //邀请者。目前仅当是由本企业内部成员邀请入群时会返回该值
+		GroupNickname string  `json:"group_nickname"`    //在群里的昵称
+		Name          string  `json:"name"`              //名字。仅当 need_name = 1 时返回 如果是微信用户，则返回其在微信中设置的名字 如果是企业微信联系人，则返回其设置对外展示的别名或实名
+		Unionid       string  `json:"unionid,omitempty"` //外部联系人在微信开放平台的唯一身份标识（微信unionid），通过此字段企业可将外部联系人与公众号/小程序用户关联起来。仅当群成员类型是微信用户（包括企业成员未添加好友），且企业绑定了微信开发者ID有此字段（查看绑定方法）。第三方不可获取，上游企业不可获取下游企业客户的unionid字段
+	}
+	Admin struct {
+		Userid string `json:"userid"` //群管理员userid
+	}
+	GroupChat struct { //客户群详情
+		ChatId     string   `json:"chat_id"`     //客户群ID
+		Name       string   `json:"name"`        //群名
+		Owner      string   `json:"owner"`       //群主ID
+		CreateTime int      `json:"create_time"` //群的创建时间
+		Notice     string   `json:"notice"`      //群公告
+		MemberList []Member `json:"member_list"` //群成员列表
+		AdminList  []Admin  `json:"admin_list"`  //群管理员列表
+	}
+
+	GroupChatDetailResponse struct {
+		util.CommonError
+		GroupChat GroupChat `json:"group_chat"` //客户群详情
+	}
+)
+
+// GetGroupChatDetail 获取客户群详情
+// @see https://developer.work.weixin.qq.com/document/path/92122
+func (r *Client) GetGroupChatDetail(req *GroupChatDetailRequest) (*GroupChatDetailResponse, error) {
+	accessToken, err := r.GetAccessToken()
+	if err != nil {
+		return nil, err
+	}
+	var response []byte
+	response, err = util.PostJSON(fmt.Sprintf("%s/get?access_token=%s", GroupChatURL, accessToken), req)
+	if err != nil {
+		return nil, err
+	}
+	result := &GroupChatDetailResponse{}
+	if err = util.DecodeWithError(response, result, "GetGroupChatDetail"); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+type (
+	OpengidToChatidRequest struct {
+		Opengid string `json:"opengid"`
+	}
+	OpengidToChatidResponse struct {
+		util.CommonError
+		ChatId string `json:"chat_id"` //客户群ID
+	}
+)
+
+// OpengidToChatid 客户群opengid转换
+// @see https://developer.work.weixin.qq.com/document/path/94822
+func (r *Client) OpengidToChatid(req *OpengidToChatidRequest) (*OpengidToChatidResponse, error) {
+	accessToken, err := r.GetAccessToken()
+	if err != nil {
+		return nil, err
+	}
+	var response []byte
+	response, err = util.PostJSON(fmt.Sprintf("%s?access_token=%s", OpengidToChatid, accessToken), req)
+	if err != nil {
+		return nil, err
+	}
+	result := &OpengidToChatidResponse{}
+	if err = util.DecodeWithError(response, result, "GetGroupChatDetail"); err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/work/externalcontact/join_way.go
+++ b/work/externalcontact/join_way.go
@@ -2,7 +2,7 @@ package externalcontact
 
 import (
 	"fmt"
-	
+
 	"github.com/silenceper/wechat/v2/util"
 )
 
@@ -133,7 +133,7 @@ func (r *Client) UpdateJoinWay(req *UpdateJoinWayRequest) (*util.CommonError, er
 
 // DelJoinWay 删除客户群进群方式配置
 // @see https://developer.work.weixin.qq.com/document/path/92229
-func (r *Client) DelJoinWay(req *JoinWayConfigRequest) (any, error) {
+func (r *Client) DelJoinWay(req *JoinWayConfigRequest) (*util.CommonError, error) {
 	var (
 		accessToken string
 		err         error

--- a/work/externalcontact/join_way.go
+++ b/work/externalcontact/join_way.go
@@ -9,19 +9,21 @@ import (
 const GroupChatURL = "https://qyapi.weixin.qq.com/cgi-bin/externalcontact/groupchat"
 
 type (
+	// AddJoinWayRequest 添加群配置请求参数
 	AddJoinWayRequest struct {
 		Scene          int      `json:"scene"`            // 必填 1 - 群的小程序插件,2 - 群的二维码插件
 		Remark         string   `json:"remark"`           //非必填	联系方式的备注信息，用于助记，超过30个字符将被截断
 		AutoCreateRoom int      `json:"auto_create_room"` //非必填	当群满了后，是否自动新建群。0-否；1-是。 默认为1
 		RoomBaseName   string   `json:"room_base_name"`   //非必填	自动建群的群名前缀，当auto_create_room为1时有效。最长40个utf8字符
-		RoomBaseId     int      `json:"room_base_id"`     //非必填	自动建群的群起始序号，当auto_create_room为1时有效
-		ChatIdList     []string `json:"chat_id_list"`     //必填	使用该配置的客户群ID列表，支持5个。见客户群ID获取方法
+		RoomBaseID     int      `json:"room_base_id"`     //非必填	自动建群的群起始序号，当auto_create_room为1时有效
+		ChatIDList     []string `json:"chat_id_list"`     //必填	使用该配置的客户群ID列表，支持5个。见客户群ID获取方法
 		State          string   `json:"state"`            //非必填	企业自定义的state参数，用于区分不同的入群渠道。不超过30个UTF-8字符
 	}
 
+	// AddJoinWayResponse 添加群配置返回值
 	AddJoinWayResponse struct {
 		util.CommonError
-		ConfigId string `json:"config_id"`
+		ConfigID string `json:"config_id"`
 	}
 )
 
@@ -48,22 +50,24 @@ func (r *Client) AddJoinWay(req *AddJoinWayRequest) (*AddJoinWayResponse, error)
 }
 
 type (
+	//JoinWayConfigRequest 获取或删除群配置的请求参数
 	JoinWayConfigRequest struct {
-		ConfigId string `json:"config_id"`
+		ConfigID string `json:"config_id"`
 	}
 
+	//JoinWay 群配置
 	JoinWay struct {
-		ConfigId       string   `json:"config_id"`
+		ConfigID       string   `json:"config_id"`
 		Scene          int      `json:"scene"`
 		Remark         string   `json:"remark"`
 		AutoCreateRoom int      `json:"auto_create_room"`
 		RoomBaseName   string   `json:"room_base_name"`
-		RoomBaseId     int      `json:"room_base_id"`
-		ChatIdList     []string `json:"chat_id_list"`
+		RoomBaseID     int      `json:"room_base_id"`
+		ChatIDList     []string `json:"chat_id_list"`
 		QrCode         string   `json:"qr_code"`
 		State          string   `json:"state"`
 	}
-
+	//GetJoinWayResponse 获取群配置的返回值
 	GetJoinWayResponse struct {
 		util.CommonError
 		JoinWay JoinWay `json:"join_way"`
@@ -92,14 +96,15 @@ func (r *Client) GetJoinWay(req *JoinWayConfigRequest) (*GetJoinWayResponse, err
 	return result, nil
 }
 
+// UpdateJoinWayRequest 更新群配置的请求参数
 type UpdateJoinWayRequest struct {
-	ConfigId       string   `json:"config_id"`
+	ConfigID       string   `json:"config_id"`
 	Scene          int      `json:"scene"`            // 必填 1 - 群的小程序插件,2 - 群的二维码插件
 	Remark         string   `json:"remark"`           //非必填	联系方式的备注信息，用于助记，超过30个字符将被截断
 	AutoCreateRoom int      `json:"auto_create_room"` //非必填	当群满了后，是否自动新建群。0-否；1-是。 默认为1
 	RoomBaseName   string   `json:"room_base_name"`   //非必填	自动建群的群名前缀，当auto_create_room为1时有效。最长40个utf8字符
-	RoomBaseId     int      `json:"room_base_id"`     //非必填	自动建群的群起始序号，当auto_create_room为1时有效
-	ChatIdList     []string `json:"chat_id_list"`     //必填	使用该配置的客户群ID列表，支持5个。见客户群ID获取方法
+	RoomBaseID     int      `json:"room_base_id"`     //非必填	自动建群的群起始序号，当auto_create_room为1时有效
+	ChatIDList     []string `json:"chat_id_list"`     //必填	使用该配置的客户群ID列表，支持5个。见客户群ID获取方法
 	State          string   `json:"state"`            //非必填	企业自定义的state参数，用于区分不同的入群渠道。不超过30个UTF-8字符
 }
 

--- a/work/externalcontact/join_way.go
+++ b/work/externalcontact/join_way.go
@@ -1,0 +1,148 @@
+package externalcontact
+
+import (
+	"fmt"
+	"github.com/silenceper/wechat/v2/util"
+)
+
+// GroupChatURL 客户群
+const GroupChatURL = "https://qyapi.weixin.qq.com/cgi-bin/externalcontact/groupchat"
+
+type (
+	AddJoinWayRequest struct {
+		Scene          int      `json:"scene"`            // 必填 1 - 群的小程序插件,2 - 群的二维码插件
+		Remark         string   `json:"remark"`           //非必填	联系方式的备注信息，用于助记，超过30个字符将被截断
+		AutoCreateRoom int      `json:"auto_create_room"` //非必填	当群满了后，是否自动新建群。0-否；1-是。 默认为1
+		RoomBaseName   string   `json:"room_base_name"`   //非必填	自动建群的群名前缀，当auto_create_room为1时有效。最长40个utf8字符
+		RoomBaseId     int      `json:"room_base_id"`     //非必填	自动建群的群起始序号，当auto_create_room为1时有效
+		ChatIdList     []string `json:"chat_id_list"`     //必填	使用该配置的客户群ID列表，支持5个。见客户群ID获取方法
+		State          string   `json:"state"`            //非必填	企业自定义的state参数，用于区分不同的入群渠道。不超过30个UTF-8字符
+	}
+
+	AddJoinWayResponse struct {
+		util.CommonError
+		ConfigId string `json:"config_id"`
+	}
+)
+
+// AddJoinWay 加入群聊
+// @see https://developer.work.weixin.qq.com/document/path/92229
+func (r *Client) AddJoinWay(req *AddJoinWayRequest) (*AddJoinWayResponse, error) {
+	var (
+		accessToken string
+		err         error
+		response    []byte
+	)
+	if accessToken, err = r.GetAccessToken(); err != nil {
+		return nil, err
+	}
+	response, err = util.PostJSON(fmt.Sprintf("%s/add_join_way?access_token=%s", GroupChatURL, accessToken), req)
+	if err != nil {
+		return nil, err
+	}
+	result := &AddJoinWayResponse{}
+	if err = util.DecodeWithError(response, result, "AddJoinWay"); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+type (
+	JoinWayConfigRequest struct {
+		ConfigId string `json:"config_id"`
+	}
+
+	JoinWay struct {
+		ConfigId       string   `json:"config_id"`
+		Scene          int      `json:"scene"`
+		Remark         string   `json:"remark"`
+		AutoCreateRoom int      `json:"auto_create_room"`
+		RoomBaseName   string   `json:"room_base_name"`
+		RoomBaseId     int      `json:"room_base_id"`
+		ChatIdList     []string `json:"chat_id_list"`
+		QrCode         string   `json:"qr_code"`
+		State          string   `json:"state"`
+	}
+
+	GetJoinWayResponse struct {
+		util.CommonError
+		JoinWay JoinWay `json:"join_way"`
+	}
+)
+
+// GetJoinWay 获取客户群进群方式配置
+// @see https://developer.work.weixin.qq.com/document/path/92229
+func (r *Client) GetJoinWay(req *JoinWayConfigRequest) (*GetJoinWayResponse, error) {
+	var (
+		accessToken string
+		err         error
+		response    []byte
+	)
+	if accessToken, err = r.GetAccessToken(); err != nil {
+		return nil, err
+	}
+	response, err = util.PostJSON(fmt.Sprintf("%s/get_join_way?access_token=%s", GroupChatURL, accessToken), req)
+	if err != nil {
+		return nil, err
+	}
+	result := &GetJoinWayResponse{}
+	if err = util.DecodeWithError(response, result, "GetJoinWay"); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+type UpdateJoinWayRequest struct {
+	ConfigId       string   `json:"config_id"`
+	Scene          int      `json:"scene"`            // 必填 1 - 群的小程序插件,2 - 群的二维码插件
+	Remark         string   `json:"remark"`           //非必填	联系方式的备注信息，用于助记，超过30个字符将被截断
+	AutoCreateRoom int      `json:"auto_create_room"` //非必填	当群满了后，是否自动新建群。0-否；1-是。 默认为1
+	RoomBaseName   string   `json:"room_base_name"`   //非必填	自动建群的群名前缀，当auto_create_room为1时有效。最长40个utf8字符
+	RoomBaseId     int      `json:"room_base_id"`     //非必填	自动建群的群起始序号，当auto_create_room为1时有效
+	ChatIdList     []string `json:"chat_id_list"`     //必填	使用该配置的客户群ID列表，支持5个。见客户群ID获取方法
+	State          string   `json:"state"`            //非必填	企业自定义的state参数，用于区分不同的入群渠道。不超过30个UTF-8字符
+}
+
+// UpdateJoinWay 更新客户群进群方式配置
+// @see https://developer.work.weixin.qq.com/document/path/92229
+func (r *Client) UpdateJoinWay(req *UpdateJoinWayRequest) (*util.CommonError, error) {
+	var (
+		accessToken string
+		err         error
+		response    []byte
+	)
+	if accessToken, err = r.GetAccessToken(); err != nil {
+		return nil, err
+	}
+	response, err = util.PostJSON(fmt.Sprintf("%s/update_join_way?access_token=%s", GroupChatURL, accessToken), req)
+	if err != nil {
+		return nil, err
+	}
+	result := &util.CommonError{}
+	if err = util.DecodeWithError(response, result, "UpdateJoinWay"); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// DelJoinWay 删除客户群进群方式配置
+// @see https://developer.work.weixin.qq.com/document/path/92229
+func (r *Client) DelJoinWay(req *JoinWayConfigRequest) (any, error) {
+	var (
+		accessToken string
+		err         error
+		response    []byte
+	)
+	if accessToken, err = r.GetAccessToken(); err != nil {
+		return nil, err
+	}
+	response, err = util.PostJSON(fmt.Sprintf("%s/del_join_way?access_token=%s", GroupChatURL, accessToken), req)
+	if err != nil {
+		return nil, err
+	}
+	result := &util.CommonError{}
+	if err = util.DecodeWithError(response, result, "DelJoinWay"); err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/work/externalcontact/join_way.go
+++ b/work/externalcontact/join_way.go
@@ -2,6 +2,7 @@ package externalcontact
 
 import (
 	"fmt"
+	
 	"github.com/silenceper/wechat/v2/util"
 )
 

--- a/work/externalcontact/join_way.go
+++ b/work/externalcontact/join_way.go
@@ -111,44 +111,36 @@ type UpdateJoinWayRequest struct {
 
 // UpdateJoinWay 更新客户群进群方式配置
 // @see https://developer.work.weixin.qq.com/document/path/92229
-func (r *Client) UpdateJoinWay(req *UpdateJoinWayRequest) (*util.CommonError, error) {
+func (r *Client) UpdateJoinWay(req *UpdateJoinWayRequest) error {
 	var (
 		accessToken string
 		err         error
 		response    []byte
 	)
 	if accessToken, err = r.GetAccessToken(); err != nil {
-		return nil, err
+		return err
 	}
 	response, err = util.PostJSON(fmt.Sprintf("%s/update_join_way?access_token=%s", GroupChatURL, accessToken), req)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	result := &util.CommonError{}
-	if err = util.DecodeWithError(response, result, "UpdateJoinWay"); err != nil {
-		return nil, err
-	}
-	return result, nil
+	return util.DecodeWithCommonError(response, "UpdateJoinWay")
 }
 
 // DelJoinWay 删除客户群进群方式配置
 // @see https://developer.work.weixin.qq.com/document/path/92229
-func (r *Client) DelJoinWay(req *JoinWayConfigRequest) (*util.CommonError, error) {
+func (r *Client) DelJoinWay(req *JoinWayConfigRequest) error {
 	var (
 		accessToken string
 		err         error
 		response    []byte
 	)
 	if accessToken, err = r.GetAccessToken(); err != nil {
-		return nil, err
+		return err
 	}
 	response, err = util.PostJSON(fmt.Sprintf("%s/del_join_way?access_token=%s", GroupChatURL, accessToken), req)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	result := &util.CommonError{}
-	if err = util.DecodeWithError(response, result, "DelJoinWay"); err != nil {
-		return nil, err
-	}
-	return result, nil
+	return util.DecodeWithCommonError(response, "DelJoinWay")
 }


### PR DESCRIPTION
企业微信客户群进群方式配置
为了获取客户群ChatId
把客户群列表，明细，openid转ChatId也一起做了下
照着前辈的模子做的，本地也试了下，应该没啥问题
PS：个人首次贡献代码，go初学者