### PR TITLE
service_userid错误，正确为servicer_userid

### DIFF
--- a/work/kf/servicestate.go
+++ b/work/kf/servicestate.go
@@ -24,7 +24,7 @@ type ServiceStateGetOptions struct {
 type ServiceStateGetSchema struct {
 	util.CommonError
 	ServiceState  int    `json:"service_state"`  // 当前的会话状态，状态定义参考概述中的表格
-	ServiceUserID string `json:"service_userid"` // 接待人员的userid，仅当state=3时有效
+	ServiceUserID string `json:"servicer_userid"` // 接待人员的userid，仅当state=3时有效
 }
 
 // ServiceStateGet 获取会话状态


### PR DESCRIPTION
官方返回结构：
{
    "errcode": 0,
    "errmsg": "ok",
    "service_state": 3,
    "servicer_userid": "xxx"
}

官方文档：https://developer.work.weixin.qq.com/document/path/94698