### PR TITLE
微信网页授权结果新增快照用户标记

### DIFF
--- a/officialaccount/oauth/oauth.go
+++ b/officialaccount/oauth/oauth.go
@@ -64,6 +64,10 @@ type ResAccessToken struct {
 	OpenID       string `json:"openid"`
 	Scope        string `json:"scope"`
 
+	// IsSnapShotUser 是否为快照页模式虚拟账号，只有当用户是快照页模式虚拟账号时返回，值为1
+	// 公众号文档 https://developers.weixin.qq.com/community/minihome/doc/000c2c34068880629ced91a2f56001
+	IsSnapShotUser int `json:"is_snapshotuser"`
+
 	// UnionID 只有在用户将公众号绑定到微信开放平台帐号后，才会出现该字段。
 	// 公众号文档 https://mp.weixin.qq.com/wiki?t=resource/res_main&id=mp1421140842
 	UnionID string `json:"unionid"`


### PR DESCRIPTION
新返回结果预览
```
{
  "access_token":"ACCESS_TOKEN",
  "expires_in":7200,
  "refresh_token":"REFRESH_TOKEN",
  "openid":"OPENID",
  "scope":"SCOPE",
  "is_snapshotuser": 1,
  "unionid": "UNIONID"
}
```

微信公告：https://developers.weixin.qq.com/community/minihome/doc/000c2c34068880629ced91a2f56001