### PR TITLE
补全模板消息API中遗漏的 ‘防重入ID’ 参数

### DIFF
--- a/officialaccount/message/template.go
+++ b/officialaccount/message/template.go
@@ -29,11 +29,12 @@ func NewTemplate(context *context.Context) *Template {
 
 // TemplateMessage 发送的模板消息内容
 type TemplateMessage struct {
-	ToUser     string                       `json:"touser"`          // 必须, 接受者OpenID
-	TemplateID string                       `json:"template_id"`     // 必须, 模版ID
-	URL        string                       `json:"url,omitempty"`   // 可选, 用户点击后跳转的URL, 该URL必须处于开发者在公众平台网站中设置的域中
-	Color      string                       `json:"color,omitempty"` // 可选, 整个消息的颜色, 可以不设置
-	Data       map[string]*TemplateDataItem `json:"data"`            // 必须, 模板数据
+	ToUser      string                       `json:"touser"`                  // 必须, 接受者OpenID
+	TemplateID  string                       `json:"template_id"`             // 必须, 模版ID
+	URL         string                       `json:"url,omitempty"`           // 可选, 用户点击后跳转的URL, 该URL必须处于开发者在公众平台网站中设置的域中
+	Color       string                       `json:"color,omitempty"`         // 可选, 整个消息的颜色, 可以不设置
+	Data        map[string]*TemplateDataItem `json:"data"`                    // 必须, 模板数据
+	ClientMsgID string                       `json:"client_msg_id,omitempty"` // 可选, 防重入ID
 
 	MiniProgram struct {
 		AppID    string `json:"appid"`    // 所需跳转到的小程序appid（该小程序appid必须与发模板消息的公众号是绑定关联关系）


### PR DESCRIPTION
client_msg_id：
防重入id。
对于同一个openid + client_msg_id, 只发送一条消息,10分钟有效,超过10分钟不保证效果。若无防重入需求，可不填