### PR TITLE
增加发送图文消息（点击跳转到图文消息页面）使用通过 “发布” 系列接口得到的 article_id

### DIFF
--- a/officialaccount/message/customer_message.go
+++ b/officialaccount/message/customer_message.go
@@ -38,6 +38,7 @@ type CustomerMessage struct {
 	Wxcard          *MediaWxcard          `json:"wxcard,omitempty"`          // 可选
 	Msgmenu         *MediaMsgmenu         `json:"msgmenu,omitempty"`         // 可选
 	Miniprogrampage *MediaMiniprogrampage `json:"miniprogrampage,omitempty"` // 可选
+	Mpnewsarticle   *MediaArticle         `json:"mpnewsarticle,omitempty"`   // 可选
 }
 
 // NewCustomerTextMessage 文本消息结构体构造方法
@@ -95,6 +96,11 @@ type MediaText struct {
 // MediaResource  消息使用的永久素材id
 type MediaResource struct {
 	MediaID string `json:"media_id"`
+}
+
+// MediaArticle  消息使用的已发布文章id
+type MediaArticle struct {
+	ArticleID string `json:"article_id"`
 }
 
 // MediaVideo 视频消息包含的内容


### PR DESCRIPTION
https://developers.weixin.qq.com/doc/offiaccount/Message_Management/Service_Center_messages.html#%E5%AE%A2%E6%9C%8D%E6%8E%A5%E5%8F%A3-%E5%8F%91%E6%B6%88%E6%81%AF

发送图文消息（点击跳转到图文消息页面）使用通过 “发布” 系列接口得到的 article_id

注意: 草稿接口灰度完成后，将不再支持此前客服接口中带 media_id 的 mpnews 类型的图文消息

{
    "touser":"OPENID",
    "msgtype":"mpnewsarticle",
    "mpnewsarticle": {
         "article_id":"ARTICLE_ID"
    }
}