### PR TITLE
chore: 转移 cache 初始化到 Wechat 结构体方法下

### DIFF
--- a/openplatform/openplatform.go
+++ b/openplatform/openplatform.go
@@ -18,9 +18,6 @@ type OpenPlatform struct {
 
 // NewOpenPlatform new openplatform
 func NewOpenPlatform(cfg *config.Config) *OpenPlatform {
-	if cfg.Cache == nil {
-		panic("cache 未设置")
-	}
 	ctx := &context.Context{
 		Config: cfg,
 	}

--- a/wechat.go
+++ b/wechat.go
@@ -68,6 +68,9 @@ func (wc *Wechat) GetPay(cfg *payConfig.Config) *pay.Pay {
 
 // GetOpenPlatform 获取微信开放平台的实例
 func (wc *Wechat) GetOpenPlatform(cfg *openConfig.Config) *openplatform.OpenPlatform {
+	if cfg.Cache == nil {
+		cfg.Cache = wc.cache
+	}
 	return openplatform.NewOpenPlatform(cfg)
 }
 


### PR DESCRIPTION
chore: 移除 panic，转移 cache 初始化到 Wechat 结构体方法下；在使用时可以只设置一次 cache 同时避免 panic 出现