### PR TITLE
fix  CallbackMessage open_kfid  and SyncMsg error

### DIFF
--- a/work/kf/callback.go
+++ b/work/kf/callback.go
@@ -52,12 +52,12 @@ type callbackOriginMessage struct {
 
 // CallbackMessage 微信客服回调消息
 type CallbackMessage struct {
-	ToUserName string `json:"to_user_name"`             // 微信客服组件ID
-	CreateTime int    `json:"create_time"`              // 消息创建时间，unix时间戳
-	MsgType    string `json:"msgtype"`                  // 消息的类型，此时固定为 event
-	Event      string `json:"event"`                    // 事件的类型，此时固定为 kf_msg_or_event
-	Token      string `json:"token"`                    // 调用拉取消息接口时，需要传此token，用于校验请求的合法性
-	OpenKfID   string `json:"open_kfid" xml:"OpenKfId"` // 有新消息的客服帐号。可通过sync_msg接口指定open_kfid获取此客服帐号的消息
+	ToUserName string `json:"to_user_name" xml:"ToUserName"` // 微信客服组件ID
+	CreateTime int    `json:"create_time" xml:"CreateTime"`  // 消息创建时间，unix时间戳
+	MsgType    string `json:"msgtype" xml:"MsgType"`         // 消息的类型，此时固定为 event
+	Event      string `json:"event" xml:"Event"`             // 事件的类型，此时固定为 kf_msg_or_event
+	Token      string `json:"token" xml:"Token"`             // 调用拉取消息接口时，需要传此token，用于校验请求的合法性
+	OpenKfID   string `json:"open_kfid" xml:"OpenKfId"`      // 有新消息的客服帐号。可通过sync_msg接口指定open_kfid获取此客服帐号的消息
 }
 
 // GetCallbackMessage 获取回调事件中的消息内容

--- a/work/kf/callback.go
+++ b/work/kf/callback.go
@@ -52,12 +52,12 @@ type callbackOriginMessage struct {
 
 // CallbackMessage 微信客服回调消息
 type CallbackMessage struct {
-	ToUserName string `json:"to_user_name"` // 微信客服组件ID
-	CreateTime int    `json:"create_time"`  // 消息创建时间，unix时间戳
-	MsgType    string `json:"msgtype"`      // 消息的类型，此时固定为 event
-	Event      string `json:"event"`        // 事件的类型，此时固定为 kf_msg_or_event
-	Token      string `json:"token"`        // 调用拉取消息接口时，需要传此token，用于校验请求的合法性
-	OpenKfID   string `json:"open_kfid"`    // 有新消息的客服帐号。可通过sync_msg接口指定open_kfid获取此客服帐号的消息
+	ToUserName string `json:"to_user_name"`             // 微信客服组件ID
+	CreateTime int    `json:"create_time"`              // 消息创建时间，unix时间戳
+	MsgType    string `json:"msgtype"`                  // 消息的类型，此时固定为 event
+	Event      string `json:"event"`                    // 事件的类型，此时固定为 kf_msg_or_event
+	Token      string `json:"token"`                    // 调用拉取消息接口时，需要传此token，用于校验请求的合法性
+	OpenKfID   string `json:"open_kfid" xml:"OpenKfId"` // 有新消息的客服帐号。可通过sync_msg接口指定open_kfid获取此客服帐号的消息
 }
 
 // GetCallbackMessage 获取回调事件中的消息内容

--- a/work/kf/callback.go
+++ b/work/kf/callback.go
@@ -57,6 +57,7 @@ type CallbackMessage struct {
 	MsgType    string `json:"msgtype"`      // 消息的类型，此时固定为 event
 	Event      string `json:"event"`        // 事件的类型，此时固定为 kf_msg_or_event
 	Token      string `json:"token"`        // 调用拉取消息接口时，需要传此token，用于校验请求的合法性
+	OpenKfId   string `json:"open_kfid"`    // 有新消息的客服帐号。可通过sync_msg接口指定open_kfid获取此客服帐号的消息
 }
 
 // GetCallbackMessage 获取回调事件中的消息内容

--- a/work/kf/callback.go
+++ b/work/kf/callback.go
@@ -57,7 +57,7 @@ type CallbackMessage struct {
 	MsgType    string `json:"msgtype"`      // 消息的类型，此时固定为 event
 	Event      string `json:"event"`        // 事件的类型，此时固定为 kf_msg_or_event
 	Token      string `json:"token"`        // 调用拉取消息接口时，需要传此token，用于校验请求的合法性
-	OpenKfId   string `json:"open_kfid"`    // 有新消息的客服帐号。可通过sync_msg接口指定open_kfid获取此客服帐号的消息
+	OpenKfID   string `json:"open_kfid"`    // 有新消息的客服帐号。可通过sync_msg接口指定open_kfid获取此客服帐号的消息
 }
 
 // GetCallbackMessage 获取回调事件中的消息内容

--- a/work/kf/syncmsg.go
+++ b/work/kf/syncmsg.go
@@ -16,9 +16,11 @@ const (
 
 // SyncMsgOptions 获取消息查询参数
 type SyncMsgOptions struct {
-	Cursor string `json:"cursor"` // 上一次调用时返回的next_cursor，第一次拉取可以不填, 不多于64字节
-	Token  string `json:"token"`  // 回调事件返回的token字段，10分钟内有效；可不填，如果不填接口有严格的频率限制, 不多于128字节
-	Limit  uint   `json:"limit"`  // 期望请求的数据量，默认值和最大值都为1000, 注意：可能会出现返回条数少于limit的情况，需结合返回的has_more字段判断是否继续请求。
+	Cursor      string `json:"cursor"`       // 上一次调用时返回的next_cursor，第一次拉取可以不填, 不多于64字节
+	Token       string `json:"token"`        // 回调事件返回的token字段，10分钟内有效；可不填，如果不填接口有严格的频率限制, 不多于128字节
+	Limit       uint   `json:"limit"`        // 期望请求的数据量，默认值和最大值都为1000, 注意：可能会出现返回条数少于limit的情况，需结合返回的has_more字段判断是否继续请求。
+	VoiceFormat uint   `json:"voice_format"` // 语音消息类型，0-Amr 1-Silk，默认0。可通过该参数控制返回的语音格式，开发者可按需选择自己程序支持的一种格式
+	OpenKfId    string `json:"open_kfid"`    // 指定拉取某个客服帐号的消息，否则默认返回有权限的客服帐号的消息。当客服帐号较多，建议按open_kfid来拉取以获取更好的性能。
 }
 
 // SyncMsgSchema 获取消息查询响应内容

--- a/work/kf/syncmsg.go
+++ b/work/kf/syncmsg.go
@@ -16,11 +16,11 @@ const (
 
 // SyncMsgOptions 获取消息查询参数
 type SyncMsgOptions struct {
-	Cursor      string `json:"cursor"`       // 上一次调用时返回的next_cursor，第一次拉取可以不填, 不多于64字节
-	Token       string `json:"token"`        // 回调事件返回的token字段，10分钟内有效；可不填，如果不填接口有严格的频率限制, 不多于128字节
-	Limit       uint   `json:"limit"`        // 期望请求的数据量，默认值和最大值都为1000, 注意：可能会出现返回条数少于limit的情况，需结合返回的has_more字段判断是否继续请求。
-	VoiceFormat uint   `json:"voice_format"` // 语音消息类型，0-Amr 1-Silk，默认0。可通过该参数控制返回的语音格式，开发者可按需选择自己程序支持的一种格式
-	OpenKfID    string `json:"open_kfid"`    // 指定拉取某个客服帐号的消息，否则默认返回有权限的客服帐号的消息。当客服帐号较多，建议按open_kfid来拉取以获取更好的性能。
+	Cursor      string `json:"cursor"`                 // 上一次调用时返回的next_cursor，第一次拉取可以不填, 不多于64字节
+	Token       string `json:"token"`                  // 回调事件返回的token字段，10分钟内有效；可不填，如果不填接口有严格的频率限制, 不多于128字节
+	Limit       uint   `json:"limit"`                  // 期望请求的数据量，默认值和最大值都为1000, 注意：可能会出现返回条数少于limit的情况，需结合返回的has_more字段判断是否继续请求。
+	VoiceFormat uint   `json:"voice_format,omitempty"` // 语音消息类型，0-Amr 1-Silk，默认0。可通过该参数控制返回的语音格式，开发者可按需选择自己程序支持的一种格式
+	OpenKfID    string `json:"open_kfid,omitempty"`    // 指定拉取某个客服帐号的消息，否则默认返回有权限的客服帐号的消息。当客服帐号较多，建议按open_kfid来拉取以获取更好的性能。
 }
 
 // SyncMsgSchema 获取消息查询响应内容

--- a/work/kf/syncmsg.go
+++ b/work/kf/syncmsg.go
@@ -20,7 +20,7 @@ type SyncMsgOptions struct {
 	Token       string `json:"token"`        // 回调事件返回的token字段，10分钟内有效；可不填，如果不填接口有严格的频率限制, 不多于128字节
 	Limit       uint   `json:"limit"`        // 期望请求的数据量，默认值和最大值都为1000, 注意：可能会出现返回条数少于limit的情况，需结合返回的has_more字段判断是否继续请求。
 	VoiceFormat uint   `json:"voice_format"` // 语音消息类型，0-Amr 1-Silk，默认0。可通过该参数控制返回的语音格式，开发者可按需选择自己程序支持的一种格式
-	OpenKfId    string `json:"open_kfid"`    // 指定拉取某个客服帐号的消息，否则默认返回有权限的客服帐号的消息。当客服帐号较多，建议按open_kfid来拉取以获取更好的性能。
+	OpenKfID    string `json:"open_kfid"`    // 指定拉取某个客服帐号的消息，否则默认返回有权限的客服帐号的消息。当客服帐号较多，建议按open_kfid来拉取以获取更好的性能。
 }
 
 // SyncMsgSchema 获取消息查询响应内容


### PR DESCRIPTION
1.  open_kfid xml Unmarshal error
``` golang
const exp = `<xml>
	<ToUserName><![CDATA[ww12345678910]]></ToUserName>
	<CreateTime>1348831860</CreateTime>
	<MsgType><![CDATA[event]]></MsgType>
	<Event><![CDATA[kf_msg_or_event]]></Event>
	<Token><![CDATA[ENCApHxnGDNAVNY4AaSJKj4Tb5mwsEMzxhFmHVGcra996NR]]></Token>
	<OpenKfId><![CDATA[wkxxxxxxx]]></OpenKfId>
	</xml>`

type CallbackMessage struct {
	ToUserName string `json:"to_user_name"`             // 微信客服组件ID
	CreateTime int    `json:"create_time"`              // 消息创建时间，unix时间戳
	MsgType    string `json:"msgtype"`                  // 消息的类型，此时固定为 event
	Event      string `json:"event"`                    // 事件的类型，此时固定为 kf_msg_or_event
	Token      string `json:"token"`                    // 调用拉取消息接口时，需要传此token，用于校验请求的合法性
	OpenKfID   string `json:"open_kfid" xml:"OpenKfId"` // 有新消息的客服帐号。可通过sync_msg接口指定open_kfid获取此客服帐号的消息
}

var ret CallbackMessage
	if err := xml.Unmarshal([]byte(exp), &ret); err != nil {
		panic(err)
	}

        fmt.Printf("%+v", ret)
	if ret.OpenKfID != "wkxxxxxxx" {
		fmt.Println("err")
	}
```

2.  'syncMsg: field `open_kfid` unexpected empty string. invalid Request Parameter'

open_kfid 没有默认值，因此空值需要忽略整个key，不然会报错