### PR TITLE
fix: 修复缓存失效时,可能会重复获取accessToken的问题

### DIFF
--- a/credential/default_access_token.go
+++ b/credential/default_access_token.go
@@ -91,7 +91,7 @@ func (ak *DefaultAccessToken) GetAccessTokenContext(ctx context.Context) (access
 	}
 
 	expires := resAccessToken.ExpiresIn - 1500
-	_ = ak.cache.Set(accessTokenCacheKey, resAccessToken.AccessToken, time.Duration(expires)*time.Second)
+	err = ak.cache.Set(accessTokenCacheKey, resAccessToken.AccessToken, time.Duration(expires)*time.Second)
 
 	accessToken = resAccessToken.AccessToken
 	return
@@ -141,7 +141,7 @@ func (ak *StableAccessToken) GetAccessTokenContext(ctx context.Context) (accessT
 	}
 
 	expires := resAccessToken.ExpiresIn - 300
-	_ = ak.cache.Set(accessTokenCacheKey, resAccessToken.AccessToken, time.Duration(expires)*time.Second)
+	err = ak.cache.Set(accessTokenCacheKey, resAccessToken.AccessToken, time.Duration(expires)*time.Second)
 
 	accessToken = resAccessToken.AccessToken
 	return
@@ -218,7 +218,7 @@ func (ak *WorkAccessToken) GetAccessTokenContext(ctx context.Context) (accessTok
 	}
 
 	expires := resAccessToken.ExpiresIn - 1500
-	_ = ak.cache.Set(accessTokenCacheKey, resAccessToken.AccessToken, time.Duration(expires)*time.Second)
+	err = ak.cache.Set(accessTokenCacheKey, resAccessToken.AccessToken, time.Duration(expires)*time.Second)
 
 	accessToken = resAccessToken.AccessToken
 	return

--- a/credential/default_access_token.go
+++ b/credential/default_access_token.go
@@ -90,9 +90,9 @@ func (ak *DefaultAccessToken) GetAccessTokenContext(ctx context.Context) (access
 		return
 	}
 
-	if err = ak.cache.Set(accessTokenCacheKey, resAccessToken.AccessToken, time.Duration(resAccessToken.ExpiresIn-1500)*time.Second); err != nil {
-		return
-	}
+	expires := resAccessToken.ExpiresIn - 1500
+	_ = ak.cache.Set(accessTokenCacheKey, resAccessToken.AccessToken, time.Duration(expires)*time.Second)
+
 	accessToken = resAccessToken.AccessToken
 	return
 }
@@ -218,10 +218,8 @@ func (ak *WorkAccessToken) GetAccessTokenContext(ctx context.Context) (accessTok
 	}
 
 	expires := resAccessToken.ExpiresIn - 1500
-	err = ak.cache.Set(accessTokenCacheKey, resAccessToken.AccessToken, time.Duration(expires)*time.Second)
-	if err != nil {
-		return
-	}
+	_ = ak.cache.Set(accessTokenCacheKey, resAccessToken.AccessToken, time.Duration(expires)*time.Second)
+
 	accessToken = resAccessToken.AccessToken
 	return
 }


### PR DESCRIPTION
缓存中间间失效时（如Redis链接断开、失效等情况），从微信服务器获取到accessToken后，因为设置缓存失败，会导致返回为空，此时客户端会认为没有获取到token。
因此缓存设置失效时，也正常设置token，暂时启用缓存，防止获取Token API调用次数耗尽