### PR TITLE
fix:群发视频消息及预览图片消息错误修复

### DIFF
--- a/officialaccount/broadcast/broadcast.go
+++ b/officialaccount/broadcast/broadcast.go
@@ -79,6 +79,8 @@ type sendRequest struct {
 	Mpnews map[string]interface{} `json:"mpnews,omitempty"`
 	// 发送语音
 	Voice map[string]interface{} `json:"voice,omitempty"`
+	// 发送视频
+	Mpvideo map[string]interface{} `json:"mpvideo,omitempty"`
 	// 发送图片-预览使用
 	Image map[string]interface{} `json:"image,omitempty"`
 	// 发送图片
@@ -213,7 +215,7 @@ func (broadcast *Broadcast) SendVideo(user *User, mediaID string, title, descrip
 		ToUser:  nil,
 		MsgType: MsgTypeVideo,
 	}
-	req.Voice = map[string]interface{}{
+	req.Mpvideo = map[string]interface{}{
 		"media_id":    mediaID,
 		"title":       title,
 		"description": description,

--- a/officialaccount/broadcast/broadcast.go
+++ b/officialaccount/broadcast/broadcast.go
@@ -79,6 +79,8 @@ type sendRequest struct {
 	Mpnews map[string]interface{} `json:"mpnews,omitempty"`
 	// 发送语音
 	Voice map[string]interface{} `json:"voice,omitempty"`
+	// 发送图片-预览使用
+	Image map[string]interface{} `json:"image,omitempty"`
 	// 发送图片
 	Images *Image `json:"images,omitempty"`
 	// 发送卡券
@@ -183,7 +185,13 @@ func (broadcast *Broadcast) SendImage(user *User, images *Image) (*Result, error
 		ToUser:  nil,
 		MsgType: MsgTypeImage,
 	}
-	req.Images = images
+	if broadcast.preview {
+		req.Image = map[string]interface{}{
+			"media_id": images.MediaIDs[0],
+		}
+	} else {
+		req.Images = images
+	}
 	req, sendURL := broadcast.chooseTagOrOpenID(user, req)
 	url := fmt.Sprintf("%s?access_token=%s", sendURL, ak)
 	data, err := util.PostJSON(url, req)


### PR DESCRIPTION
1. 群发图片消息，由于预览接口数据格式和正式发送接口不同，造成预览消息发生失败
```
// 正式数据格式
{
   "images": {
      "media_ids": [
         "aaa"
      ],
   }
}

// 预览数据格式
{
    "image":{      
         "media_id":"aaa"
    },
}
```

2. 视频消息参数名称为mpvideo
```
{
    "mpvideo":{
          "media_id":"IhdaAQXuvJtGzwwc0abfXnzeezfO0NgPK6AQYShD8RQYMTtfzbLdBIQkQziv2XJc"
     },
}
```