### PR TITLE
officeaccount 和 miniprogram 添加UseStableAK 配置项

### DIFF
--- a/miniprogram/config/config.go
+++ b/miniprogram/config/config.go
@@ -14,4 +14,5 @@ type Config struct {
 	Token          string `json:"token"`            // token
 	EncodingAESKey string `json:"encoding_aes_key"` // EncodingAESKey
 	Cache          cache.Cache
+	UseStableAK    bool // use the stable access_token
 }

--- a/miniprogram/miniprogram.go
+++ b/miniprogram/miniprogram.go
@@ -34,7 +34,13 @@ type MiniProgram struct {
 
 // NewMiniProgram 实例化小程序 API
 func NewMiniProgram(cfg *config.Config) *MiniProgram {
-	defaultAkHandle := credential.NewDefaultAccessToken(cfg.AppID, cfg.AppSecret, credential.CacheKeyMiniProgramPrefix, cfg.Cache)
+	var defaultAkHandle credential.AccessTokenContextHandle
+	const cacheKeyPrefix = credential.CacheKeyMiniProgramPrefix
+	if cfg.UseStableAK {
+		defaultAkHandle = credential.NewStableAccessToken(cfg.AppID, cfg.AppSecret, cacheKeyPrefix, cfg.Cache)
+	} else {
+		defaultAkHandle = credential.NewDefaultAccessToken(cfg.AppID, cfg.AppSecret, cacheKeyPrefix, cfg.Cache)
+	}
 	ctx := &context.Context{
 		Config:            cfg,
 		AccessTokenHandle: defaultAkHandle,

--- a/officialaccount/config/config.go
+++ b/officialaccount/config/config.go
@@ -11,4 +11,5 @@ type Config struct {
 	Token          string `json:"token"`            // token
 	EncodingAESKey string `json:"encoding_aes_key"` // EncodingAESKey
 	Cache          cache.Cache
+	UseStableAK    bool // use the stable access_token
 }

--- a/officialaccount/officialaccount.go
+++ b/officialaccount/officialaccount.go
@@ -49,7 +49,13 @@ type OfficialAccount struct {
 
 // NewOfficialAccount 实例化公众号API
 func NewOfficialAccount(cfg *config.Config) *OfficialAccount {
-	defaultAkHandle := credential.NewDefaultAccessToken(cfg.AppID, cfg.AppSecret, credential.CacheKeyOfficialAccountPrefix, cfg.Cache)
+	var defaultAkHandle credential.AccessTokenContextHandle
+	const cacheKeyPrefix = credential.CacheKeyOfficialAccountPrefix
+	if cfg.UseStableAK {
+		defaultAkHandle = credential.NewStableAccessToken(cfg.AppID, cfg.AppSecret, cacheKeyPrefix, cfg.Cache)
+	} else {
+		defaultAkHandle = credential.NewDefaultAccessToken(cfg.AppID, cfg.AppSecret, cacheKeyPrefix, cfg.Cache)
+	}
 	ctx := &context.Context{
 		Config:            cfg,
 		AccessTokenHandle: defaultAkHandle,


### PR DESCRIPTION
允许创建OfficialAccount和MiniProgram实例时直接使用StableAccessToken