### PR TITLE
use context when getting access token

### DIFF
--- a/credential/access_token.go
+++ b/credential/access_token.go
@@ -7,10 +7,12 @@ type AccessTokenHandle interface {
 	GetAccessToken() (accessToken string, err error)
 }
 
+// AccessTokenCompatibleHandle 允许 AccessTokenHandle 兼容 AccessTokenContextHandle.
 type AccessTokenCompatibleHandle struct {
 	AccessTokenHandle
 }
 
+// GetAccessTokenContext 获取access_token,先从cache中获取，没有则从服务端获取
 func (c AccessTokenCompatibleHandle) GetAccessTokenContext(_ context.Context) (accessToken string, err error) {
 	return c.GetAccessToken()
 }

--- a/credential/access_token.go
+++ b/credential/access_token.go
@@ -7,6 +7,14 @@ type AccessTokenHandle interface {
 	GetAccessToken() (accessToken string, err error)
 }
 
+type AccessTokenCompatibleHandle struct {
+	AccessTokenHandle
+}
+
+func (c AccessTokenCompatibleHandle) GetAccessTokenContext(_ context.Context) (accessToken string, err error) {
+	return c.GetAccessToken()
+}
+
 // AccessTokenContextHandle AccessToken 接口
 type AccessTokenContextHandle interface {
 	AccessTokenHandle

--- a/credential/access_token.go
+++ b/credential/access_token.go
@@ -7,7 +7,7 @@ type AccessTokenHandle interface {
 	GetAccessToken() (accessToken string, err error)
 }
 
-// AccessTokenCompatibleHandle 允许 AccessTokenHandle 兼容 AccessTokenContextHandle.
+// AccessTokenCompatibleHandle 同时实现 AccessTokenHandle 和 AccessTokenContextHandle
 type AccessTokenCompatibleHandle struct {
 	AccessTokenHandle
 }

--- a/miniprogram/business/phone_number.go
+++ b/miniprogram/business/phone_number.go
@@ -34,7 +34,7 @@ func (business *Business) GetPhoneNumber(in *GetPhoneNumberRequest) (info PhoneI
 
 // GetPhoneNumberWithContext 利用context将code换取用户手机号。 每个code只能使用一次，code的有效期为5min
 func (business *Business) GetPhoneNumberWithContext(ctx context.Context, in *GetPhoneNumberRequest) (info PhoneInfo, err error) {
-	accessToken, err := business.GetAccessToken()
+	accessToken, err := business.GetAccessTokenContext(ctx)
 	if err != nil {
 		return
 	}

--- a/miniprogram/context/context.go
+++ b/miniprogram/context/context.go
@@ -8,5 +8,5 @@ import (
 // Context struct
 type Context struct {
 	*config.Config
-	credential.AccessTokenHandle
+	credential.AccessTokenContextHandle
 }

--- a/miniprogram/miniprogram.go
+++ b/miniprogram/miniprogram.go
@@ -55,6 +55,11 @@ func (miniProgram *MiniProgram) SetAccessTokenHandle(accessTokenHandle credentia
 	}
 }
 
+// SetAccessTokenContextHandle 自定义 access_token 获取方式
+func (miniProgram *MiniProgram) SetAccessTokenContextHandle(accessTokenContextHandle credential.AccessTokenContextHandle) {
+	miniProgram.ctx.AccessTokenContextHandle = accessTokenContextHandle
+}
+
 // GetContext get Context
 func (miniProgram *MiniProgram) GetContext() *context.Context {
 	return miniProgram.ctx

--- a/miniprogram/miniprogram.go
+++ b/miniprogram/miniprogram.go
@@ -42,15 +42,17 @@ func NewMiniProgram(cfg *config.Config) *MiniProgram {
 		defaultAkHandle = credential.NewDefaultAccessToken(cfg.AppID, cfg.AppSecret, cacheKeyPrefix, cfg.Cache)
 	}
 	ctx := &context.Context{
-		Config:            cfg,
-		AccessTokenHandle: defaultAkHandle,
+		Config:                   cfg,
+		AccessTokenContextHandle: defaultAkHandle,
 	}
 	return &MiniProgram{ctx}
 }
 
 // SetAccessTokenHandle 自定义 access_token 获取方式
 func (miniProgram *MiniProgram) SetAccessTokenHandle(accessTokenHandle credential.AccessTokenHandle) {
-	miniProgram.ctx.AccessTokenHandle = accessTokenHandle
+	miniProgram.ctx.AccessTokenContextHandle = credential.AccessTokenCompatibleHandle{
+		AccessTokenHandle: accessTokenHandle,
+	}
 }
 
 // GetContext get Context

--- a/openplatform/miniprogram/miniprogram.go
+++ b/openplatform/miniprogram/miniprogram.go
@@ -1,6 +1,7 @@
 package miniprogram
 
 import (
+	originalContext "context"
 	"fmt"
 
 	"github.com/silenceper/wechat/v2/credential"
@@ -31,6 +32,22 @@ func (miniProgram *MiniProgram) GetAccessToken() (string, error) {
 		return "", fmt.Errorf("please set the authorizer_refresh_token first")
 	}
 	akRes, akResErr := miniProgram.GetComponent().RefreshAuthrToken(miniProgram.AppID, miniProgram.authorizerRefreshToken)
+	if akResErr != nil {
+		return "", akResErr
+	}
+	return akRes.AccessToken, nil
+}
+
+// GetAccessTokenContext 利用ctx获取ak
+func (miniProgram *MiniProgram) GetAccessTokenContext(ctx originalContext.Context) (string, error) {
+	ak, akErr := miniProgram.openContext.GetAuthrAccessTokenContext(ctx, miniProgram.AppID)
+	if akErr == nil {
+		return ak, nil
+	}
+	if miniProgram.authorizerRefreshToken == "" {
+		return "", fmt.Errorf("please set the authorizer_refresh_token first")
+	}
+	akRes, akResErr := miniProgram.GetComponent().RefreshAuthrTokenContext(ctx, miniProgram.AppID, miniProgram.authorizerRefreshToken)
 	if akResErr != nil {
 		return "", akResErr
 	}
@@ -68,7 +85,7 @@ func (miniProgram *MiniProgram) GetBasic() *basic.Basic {
 // GetURLLink 小程序URL Link接口 调用前需确认已调用 SetAuthorizerRefreshToken 避免由于缓存中 authorizer_access_token 过期执行中断
 func (miniProgram *MiniProgram) GetURLLink() *urllink.URLLink {
 	return urllink.NewURLLink(&miniContext.Context{
-		AccessTokenHandle: miniProgram,
+		AccessTokenContextHandle: miniProgram,
 	})
 }
 


### PR DESCRIPTION
miniprogram should use `GetAccessTokenContext()` instead of `GetAccessToken()` where possible.

#813