### PR TITLE
修改最新版本的授权地址

### DIFF
--- a/openplatform/context/accessToken.go
+++ b/openplatform/context/accessToken.go
@@ -19,7 +19,8 @@ const (
 	refreshTokenURL         = "https://api.weixin.qq.com/cgi-bin/component/api_authorizer_token?component_access_token=%s"
 	getComponentInfoURL     = "https://api.weixin.qq.com/cgi-bin/component/api_get_authorizer_info?component_access_token=%s"
 	componentLoginURL       = "https://mp.weixin.qq.com/cgi-bin/componentloginpage?component_appid=%s&pre_auth_code=%s&redirect_uri=%s&auth_type=%d&biz_appid=%s"
-	bindComponentURL        = "https://open.weixin.qq.com/wxaopen/safe/bindcomponent?action=bindcomponent&auth_type=%d&no_scan=1&component_appid=%s&pre_auth_code=%s&redirect_uri=%s&biz_appid=%s#wechat_redirect"
+	bindComponentURL        = "https://mp.weixin.qq.com/safe/bindcomponent?action=bindcomponent&auth_type=%d&no_scan=1&component_appid=%s&pre_auth_code=%s&redirect_uri=%s&biz_appid=%s#wechat_redirect"
+	bindComponentURLV2        = "https://open.weixin.qq.com/wxaopen/safe/bindcomponent?action=bindcomponent&auth_type=%d&no_scan=1&component_appid=%s&pre_auth_code=%s&redirect_uri=%s&biz_appid=%s#wechat_redirect"
 	// TODO 获取授权方选项信息
 	// getComponentConfigURL = "https://api.weixin.qq.com/cgi-bin/component/api_get_authorizer_option?component_access_token=%s"
 	// TODO 获取已授权的账号信息
@@ -134,6 +135,20 @@ func (ctx *Context) GetBindComponentURLContext(stdCtx context.Context, redirectU
 
 // GetBindComponentURL 获取第三方公众号授权链接(链接跳转，适用移动端)
 func (ctx *Context) GetBindComponentURL(redirectURI string, authType int, bizAppID string) (string, error) {
+	return ctx.GetBindComponentURLContext(context.Background(), redirectURI, authType, bizAppID)
+}
+
+// GetBindComponentURLV2Context 获取新版本第三方公众号授权链接(链接跳转，适用移动端)
+func (ctx *Context) GetBindComponentURLV2Context(stdCtx context.Context, redirectURI string, authType int, bizAppID string) (string, error) {
+	code, err := ctx.GetPreCodeContext(stdCtx)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(bindComponentURLV2, authType, ctx.AppID, code, url.QueryEscape(redirectURI), bizAppID), nil
+}
+
+// GetBindComponentURLV2 获取新版本第三方公众号授权链接(链接跳转，适用移动端)
+func (ctx *Context) GetBindComponentURLV2(redirectURI string, authType int, bizAppID string) (string, error) {
 	return ctx.GetBindComponentURLContext(context.Background(), redirectURI, authType, bizAppID)
 }
 

--- a/openplatform/context/accessToken.go
+++ b/openplatform/context/accessToken.go
@@ -226,7 +226,7 @@ func (ctx *Context) RefreshAuthrTokenContext(stdCtx context.Context, appid, refr
 		return nil, err
 	}
 	refreshTokenKey := "authorizer_refresh_token_" + appid
-	if err := cache.SetContext(stdCtx, ctx.Cache, refreshTokenKey, ret.RefreshToken, time.Second*-1); err != nil {
+	if err := cache.SetContext(stdCtx, ctx.Cache, refreshTokenKey, ret.RefreshToken, 10*365*24*60*60*time.Second); err != nil {
 		return nil, err
 	}
 	return ret, nil

--- a/openplatform/context/accessToken.go
+++ b/openplatform/context/accessToken.go
@@ -20,7 +20,7 @@ const (
 	getComponentInfoURL     = "https://api.weixin.qq.com/cgi-bin/component/api_get_authorizer_info?component_access_token=%s"
 	componentLoginURL       = "https://mp.weixin.qq.com/cgi-bin/componentloginpage?component_appid=%s&pre_auth_code=%s&redirect_uri=%s&auth_type=%d&biz_appid=%s"
 	bindComponentURL        = "https://mp.weixin.qq.com/safe/bindcomponent?action=bindcomponent&auth_type=%d&no_scan=1&component_appid=%s&pre_auth_code=%s&redirect_uri=%s&biz_appid=%s#wechat_redirect"
-	bindComponentURLV2        = "https://open.weixin.qq.com/wxaopen/safe/bindcomponent?action=bindcomponent&auth_type=%d&no_scan=1&component_appid=%s&pre_auth_code=%s&redirect_uri=%s&biz_appid=%s#wechat_redirect"
+	bindComponentURLV2      = "https://open.weixin.qq.com/wxaopen/safe/bindcomponent?action=bindcomponent&auth_type=%d&no_scan=1&component_appid=%s&pre_auth_code=%s&redirect_uri=%s&biz_appid=%s#wechat_redirect"
 	// TODO 获取授权方选项信息
 	// getComponentConfigURL = "https://api.weixin.qq.com/cgi-bin/component/api_get_authorizer_option?component_access_token=%s"
 	// TODO 获取已授权的账号信息

--- a/openplatform/context/accessToken.go
+++ b/openplatform/context/accessToken.go
@@ -225,6 +225,10 @@ func (ctx *Context) RefreshAuthrTokenContext(stdCtx context.Context, appid, refr
 	if err := cache.SetContext(stdCtx, ctx.Cache, authrTokenKey, ret.AccessToken, time.Second*time.Duration(ret.ExpiresIn-30)); err != nil {
 		return nil, err
 	}
+	refreshTokenKey := "authorizer_refresh_token_" + appid
+	if err := cache.SetContext(stdCtx, ctx.Cache, refreshTokenKey, ret.RefreshToken, time.Second*-1); err != nil {
+		return nil, err
+	}
 	return ret, nil
 }
 
@@ -238,8 +242,18 @@ func (ctx *Context) GetAuthrAccessTokenContext(stdCtx context.Context, appid str
 	authrTokenKey := "authorizer_access_token_" + appid
 	val := cache.GetContext(stdCtx, ctx.Cache, authrTokenKey)
 	if val == nil {
-		return "", fmt.Errorf("cannot get authorizer %s access token", appid)
+		refreshTokenKey := "authorizer_refresh_token_" + appid
+		val := cache.GetContext(stdCtx, ctx.Cache, refreshTokenKey)
+		if val == nil {
+			return "", fmt.Errorf("cannot get authorizer %s refresh token", appid)
+		}
+		token, err := ctx.RefreshAuthrToken(appid, val.(string))
+		if err != nil {
+			return "", err
+		}
+		return token.AccessToken, nil
 	}
+
 	return val.(string), nil
 }
 

--- a/openplatform/context/accessToken.go
+++ b/openplatform/context/accessToken.go
@@ -19,7 +19,7 @@ const (
 	refreshTokenURL         = "https://api.weixin.qq.com/cgi-bin/component/api_authorizer_token?component_access_token=%s"
 	getComponentInfoURL     = "https://api.weixin.qq.com/cgi-bin/component/api_get_authorizer_info?component_access_token=%s"
 	componentLoginURL       = "https://mp.weixin.qq.com/cgi-bin/componentloginpage?component_appid=%s&pre_auth_code=%s&redirect_uri=%s&auth_type=%d&biz_appid=%s"
-	bindComponentURL        = "https://mp.weixin.qq.com/safe/bindcomponent?action=bindcomponent&auth_type=%d&no_scan=1&component_appid=%s&pre_auth_code=%s&redirect_uri=%s&biz_appid=%s#wechat_redirect"
+	bindComponentURL        = "https://open.weixin.qq.com/wxaopen/safe/bindcomponent?action=bindcomponent&auth_type=%d&no_scan=1&component_appid=%s&pre_auth_code=%s&redirect_uri=%s&biz_appid=%s#wechat_redirect"
 	// TODO 获取授权方选项信息
 	// getComponentConfigURL = "https://api.weixin.qq.com/cgi-bin/component/api_get_authorizer_option?component_access_token=%s"
 	// TODO 获取已授权的账号信息

--- a/openplatform/context/accessToken.go
+++ b/openplatform/context/accessToken.go
@@ -247,7 +247,7 @@ func (ctx *Context) GetAuthrAccessTokenContext(stdCtx context.Context, appid str
 		if val == nil {
 			return "", fmt.Errorf("cannot get authorizer %s refresh token", appid)
 		}
-		token, err := ctx.RefreshAuthrToken(appid, val.(string))
+		token, err := ctx.RefreshAuthrTokenContext(stdCtx, appid, val.(string))
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
微信已经修改了最新版本的授权链接地址
H5版-新版 | https://open.weixin.qq.com/wxaopen/safe/bindcomponent?action=bindcomponent&no_scan=1&component_appid=xxxx&pre_auth_code=xxxxx&redirect_uri=xxxx&auth_type=xxx&biz_appid=xxxx#wechat_redirect
-- | --


