### PR TITLE
fix: ImageUpload 接口报错 'media data missing hint:'

### DIFF
--- a/util/http.go
+++ b/util/http.go
@@ -166,6 +166,7 @@ func PostFile(fieldName, filePath, uri string) ([]byte, error) {
 			IsFile:    true,
 			Fieldname: fieldName,
 			FilePath:  filePath,
+			Filename:  filePath,
 		},
 	}
 	return PostMultipartForm(fields, uri)


### PR DESCRIPTION
调用ImageUpload，报错
```
{"errcode":41005,"errmsg":"media data missing hint: [4LDlna0983e547]"}
```
经过跟postman发送请求对比，发现少了filename。

![image](https://github.com/user-attachments/assets/e6098ae1-4d0a-4ca9-a043-9e6034cc876e)

故此修复该问题