### PR TITLE
将`SubscribeMsgSentList`结构中的`ErrorCode`类型从`int`更新为`string`

### DIFF
--- a/miniprogram/message/message.go
+++ b/miniprogram/message/message.go
@@ -556,7 +556,7 @@ type SubscribeMsgSentEvent struct {
 type SubscribeMsgSentList struct {
 	TemplateID  string `xml:"TemplateId" json:"TemplateId"`
 	MsgID       string `xml:"MsgID" json:"MsgID"`
-	ErrorCode   int    `xml:"ErrorCode" json:"ErrorCode"`
+	ErrorCode   string `xml:"ErrorCode" json:"ErrorCode"`
 	ErrorStatus string `xml:"ErrorStatus" json:"ErrorStatus"`
 }
 


### PR DESCRIPTION
fix #857 