### PR TITLE
fix: 修复空 jsapi_ticket 缓存导致签名异常的问题

### DIFF
--- a/credential/default_js_ticket.go
+++ b/credential/default_js_ticket.go
@@ -56,7 +56,9 @@ func (js *DefaultJsTicket) GetTicketContext(ctx context2.Context, accessToken st
 	// 先从cache中取
 	jsAPITicketCacheKey := fmt.Sprintf("%s_jsapi_ticket_%s", js.cacheKeyPrefix, js.appID)
 	if val := js.cache.Get(jsAPITicketCacheKey); val != nil {
-		return val.(string), nil
+		if ticketStr = val.(string); ticketStr != "" {
+			return
+		}
 	}
 
 	js.jsAPITicketLock.Lock()
@@ -64,7 +66,9 @@ func (js *DefaultJsTicket) GetTicketContext(ctx context2.Context, accessToken st
 
 	// 双检，防止重复从微信服务器获取
 	if val := js.cache.Get(jsAPITicketCacheKey); val != nil {
-		return val.(string), nil
+		if ticketStr = val.(string); ticketStr != "" {
+			return
+		}
 	}
 
 	var ticket ResTicket


### PR DESCRIPTION
### 问题说明

当前 `GetTicketContext` 方法中，对缓存的判断逻辑如下：

```go
if val := js.cache.Get(jsAPITicketCacheKey); val != nil {
	return val.(string), nil
}

这里仅判断了 val != nil。

在部分缓存实现中（如 Redis），当缓存 key 不存在时，默认是空，或者 存在但值为空字符串时，返回结果可能为 ""，此时：

* val != nil 条件成立
* 但实际 ticket 为空字符串

会导致后续继续使用空的 jsapi_ticket 生成 JSSDK 签名。

